### PR TITLE
mesh: self-healing runtime in the Rust & Python SDKs (+ plaintext-wire leak demo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ Read these first — they are normative:
 - `Documentation/DCF_AUDIO_SPEC.md` — collaborative audio as an adapter over it.
 - `Documentation/DCF_GAME_SPEC.md` — multiplayer game state/events as an adapter
   over it (same fragmentation scheme as audio, on `DATA` frames).
+- `Documentation/DCF_MESH_SPEC.md` — self-healing redundancy (peer-health FSM,
+  REPORT/ROLE control, election + failover) as a `MsgMesh` control adapter.
+- `Documentation/DCF_SECURITY_EXPOSURE.md` — the plaintext wire's exposure and the
+  WireGuard / external-crypto deployment rule.
 - `Documentation/DCF_CODE_REVIEW.md` — frank, module-by-module status (consult
   before trusting any module's surface area).
 
@@ -146,6 +150,41 @@ cd codec && cargo test --test certify_superpack            # Rust
 gcc -std=c11 -I codec C_SDK/tests/test_superpack_certify.c -lm -o /tmp/sc && /tmp/sc  # C
 ```
 
+## DCF-Mesh (self-healing redundancy over the wire)
+
+A control adapter (not a new wire format) for self-healing meshes: the payload of a
+`ProtoMessage` of type **`MsgMesh = 11`**. Two messages — **REPORT** (node→master:
+`node_id + [peer_id, status, rtt]` list) and **ROLE** (master→node: assigned role +
+master_id) — are byte-certified across Python/C/Rust/Go, alongside the certified
+algorithm primitives (`peer_status`, `group_of`, `dijkstra`, `select_routes`,
+`elect`). Spec: `Documentation/DCF_MESH_SPEC.md`.
+
+- The **self-healing runtime** drives those algorithms from live PING/PONG +
+  REPORT/ROLE, and runs in the **Go, C, Rust, and Python** nodes: per-peer liveness
+  FSM (window 5, fail 3 → Unreachable, ok 2 → recover), an AUTO/master loop (AUTO
+  nodes REPORT; the master aggregates topology, runs `elect`, broadcasts ROLE), and
+  **decentralized failover** (master Unreachable → local re-election of the lowest-id
+  healthy node). Tick ~1s; a periodic `mesh-status` line shows roles/health.
+- Algorithm + control references: `codec/demod_mesh.h` (C), `codec/src/mesh.rs`
+  (Rust), `go/mesh/mesh.go` (Go), `python/MCP/meshlab_core.py` (Python). Runtimes:
+  `go/node/mesh_runtime.go`, `C_SDK/node/dcf_mesh_runtime.h`, `rust/src/mesh_runtime.rs`,
+  `python/dcf/mesh_runtime.py` (+ stdlib UDP node `python/dcf/{udp_node,proto}.py`).
+- Vectors: `Documentation/mesh_vectors.json` (+ `python/MCP/` copy) and
+  `codec/mesh_vectors.gen.h`. The runtime's *timing* is integration-tested, not
+  vectored; the algorithms + control bytes are the contract.
+- CLI (same flags everywhere): `<node> start --mode p2p|auto|master --node-id N
+  [--master PEER] --peer id@host:port` — Go/C `dcfnode start`, Rust `dcf mesh`,
+  Python `python3 python/dcf_node.py start`. The nodes interoperate (a Go master
+  assigns roles to Rust/Python AUTO nodes). The wire is plaintext — deploy behind
+  WireGuard (`Documentation/DCF_SECURITY_EXPOSURE.md`).
+
+```sh
+python3 python/MCP/gen_mesh_vectors.py /tmp/mv.json                              # regen + verify laws
+cd codec && cargo test --test certify_mesh                                       # Rust
+gcc -std=c11 -I codec C_SDK/tests/test_mesh_certify.c -lm -o /tmp/mc && /tmp/mc  # C
+cd go && go test ./mesh/                                                         # Go
+```
+
 ## Comms client (`client/`) — Tauri 2 end-user app
 
 A cross-platform communications client (Rust core + Vue UI) on `dcf-rust-sdk` + the
@@ -231,7 +270,12 @@ default devShell (`nix develop`) with all toolchains. Top-level `Dockerfile`,
 - New transports/codecs are adapters over `DeModFrame`, not new wire formats.
 - The protocol is deliberately **encryption-free** for EAR/ITAR export compliance
   (`Documentation/Specs/export_compliance.markdown`). Do not add encryption to the
-  core wire path.
+  core wire path. The flip side — the plaintext wire is fully readable by any on-path
+  observer (membership, topology/RTT, roles, message contents) — is documented in
+  `Documentation/DCF_SECURITY_EXPOSURE.md`, with a passive wiretap demo
+  (`python/dcf_node.py wiretap`, `python/tests/test_eavesdrop_leak.py`). Deploy DCF
+  inside WireGuard (or operator-supplied, export-compliant crypto) **beneath** the UDP
+  socket — never in the codec.
 - License is **LGPL-3.0** for the linkable library; GPL-3.0 is scoped to the DOOM
   example only. (The repo has historical README inconsistencies — see the code
   review.)

--- a/Documentation/DCF_MESH_SPEC.md
+++ b/Documentation/DCF_MESH_SPEC.md
@@ -1,0 +1,144 @@
+# DCF-Mesh — self-healing redundancy over the wire
+
+Status: the **certified algorithm layer** (peer-liveness FSM, RTT grouping,
+RTT-weighted Dijkstra, route failover, master election) and the **REPORT/ROLE
+control adapter** are byte/value-identical across Python (the reference,
+`python/MCP/meshlab_core.py`), C, Rust, and Go, each diffed against the shared golden
+vectors (`Documentation/mesh_vectors.json`). The **self-healing runtime** that drives
+those algorithms from live network state is implemented and verified live in the
+**Go, C, Rust, and Python** nodes.
+
+This is not a new wire format. DCF-Mesh is an **adapter over `DeModFrame`**: every
+control message is the payload of an ordinary `ProtoMessage` of type `MsgMesh = 11`
+(see `WIRE_QUANTUM_SPEC.md` for the quantum and the envelope). Self-healing is opt-in
+— a node runs it only in `auto`/`master` mode; plain `p2p` nodes are unaffected.
+
+## Motivation
+
+A DCF mesh must keep working as nodes come and go, without a single point of failure
+and without any cryptographic handshake (the wire is deliberately encryption-free —
+see `DCF_SECURITY_EXPOSURE.md`). DCF-Mesh gives each node a live, deterministic view
+of its peers' health and the mesh topology, lets an elected master assign relay/leaf
+roles for efficient forwarding, and — crucially — re-elects a new master locally and
+deterministically the instant the old one becomes unreachable. The algorithms are
+pure integer functions over small-int node ids, so every language agrees bit-for-bit;
+the runtime is the thin, per-language shell that feeds them PING/PONG and REPORT/ROLE.
+
+## 1. The certified algorithm layer
+
+Pure, deterministic functions over node ids `0..n-1` (no I/O, no floats on the
+contract path). Status constants `HEALTHY=0 / DEGRADED=1 / UNREACHABLE=2`; role
+constants `LEAF=0 / RELAY=1 / MASTER=2`; `INF=0x3FFFFFFF`, `NO_HOP=-1`,
+`ISOLATED=-1`.
+
+| Primitive | Contract |
+|-----------|----------|
+| `peer_status(events, fail_thr, ok_thr)` | Fold a health-check sequence (`1`=ok, `0`=timeout) into a status. **Sticky** `UNREACHABLE`: once `fail_thr` consecutive timeouts hit, the peer stays `UNREACHABLE` until `ok_thr` consecutive successes recover it; a single timeout from `HEALTHY` is `DEGRADED`. |
+| `group_of(rtt_ms, threshold_ms, status)` | `floor(rtt/threshold)`, or `ISOLATED` if the peer is `UNREACHABLE`. |
+| `dijkstra(n, edges, source)` | RTT-weighted shortest paths → `(dist, next_hop)`. Deterministic tie-break: smaller predecessor id. |
+| `select_routes(candidates)` | Order `(route_id, status, rtt)` candidates into a failover list: drop `UNREACHABLE`, then sort by `(status, rtt, route_id)` ascending. |
+| `elect(n, edges, relay_min_degree)` | Master = max healthy degree, tie-broken by smallest average RTT (floored), then smallest id. Nodes with degree `≥ relay_min_degree` are `RELAY`, the rest `LEAF`; the master is `MASTER`. |
+
+## 2. The control adapter (REPORT / ROLE)
+
+Big-endian, byte-exact, carried as the `MsgMesh` payload. Header byte 0 is the
+control type, byte 1 is `MESH_VERSION = 1`.
+
+**REPORT** (`type = 0`, node → master) — a node's view of its peers, `5 + 5·n` bytes:
+
+```
+type(1)=0 | ver(1)=1 | node_id(2) | n_peers(1) | n_peers × [ peer_id(2) | status(1) | rtt_ms(2) ]
+```
+
+**ROLE** (`type = 1`, master → node) — an assigned role, 7 bytes:
+
+```
+type(1)=1 | ver(1)=1 | node_id(2) | role(1) | master_id(2)
+```
+
+`pack_report`/`unpack_report` and `pack_role`/`unpack_role` live next to each
+language's mesh module (table below). Adding fields is a version bump, never a silent
+layout change — the golden vectors are the contract.
+
+## 3. The self-healing runtime
+
+A node in `auto`/`master` mode runs one tick (~**1 s**) that: (a) folds each peer's
+PONG-or-timeout into a 5-event sliding window and recomputes its status via
+`peer_status`, (b) PINGs every peer, then (c) does mode-specific work. Tuning is
+identical in every language: window cap **5**, fail threshold **3**, ok threshold
+**2**, relay min degree **2**; the `mesh-status` line is logged every **3rd** tick.
+
+- **`p2p`** — health FSM only (no control traffic, no roles).
+- **`auto`** — REPORT its peer view (status + RTT) to the configured master peer, and
+  run **decentralized failover**: if that master peer is `UNREACHABLE`, locally
+  re-elect the lowest-id healthy node (becoming master itself if it is that node). No
+  central coordinator is consulted, so the mesh heals even if the master vanishes.
+- **`master`** — aggregate every reporter's edges into a deduplicated, canonicalized
+  topology (dropping `UNREACHABLE` links, keeping the min-RTT weight per edge), map
+  ids to a dense `0..N-1` space, run `elect`, adopt its own role, and unicast each
+  reporter its `ROLE`.
+
+Status line (one per 3 ticks):
+
+```
+mesh-status node=<id> mode=<p2p|auto|master> role=<leaf|relay|master> master=<id> peers=[<id>:<status>:g<group> ...]
+```
+
+## 4. Reference implementations
+
+| Lang | Certified algorithms + control | Self-healing runtime | Node / CLI |
+|------|--------------------------------|----------------------|------------|
+| C | `codec/demod_mesh.h` | `C_SDK/node/dcf_mesh_runtime.h` | `dcfnode start` |
+| Rust | `codec/src/mesh.rs` | `rust/src/mesh_runtime.rs` | `dcf mesh` |
+| Go | `go/mesh/mesh.go` | `go/node/mesh_runtime.go` | `dcfnode start` |
+| Python | `python/MCP/meshlab_core.py` | `python/dcf/mesh_runtime.py` (+ `dcf/udp_node.py`, `dcf/proto.py`) | `python/dcf_node.py start` |
+
+All four CLIs share the same flags:
+
+```
+<node> start --mode p2p|auto|master --node-id N [--master PEER] --peer id@host:port ...
+```
+
+(`--bind host:port` selects the local UDP address; `--peer` is repeatable. The Rust
+binary spells the subcommand `dcf mesh ...`.) Because the envelope and the control
+bytes are identical, the nodes interoperate: a Go master will assign roles to a Rust
+or Python `auto` node, and killing it triggers the same local re-election everywhere.
+
+## 5. Verification
+
+The certificate is the contract — regenerate and diff on any change to a mesh module:
+
+```sh
+python3 python/MCP/gen_mesh_vectors.py /tmp/mv.json                              # Python: regen + verify laws
+cd codec && cargo test --test certify_mesh                                       # Rust
+gcc -std=c11 -I codec C_SDK/tests/test_mesh_certify.c -lm -o /tmp/mc && /tmp/mc  # C
+cd go && go test ./mesh/                                                         # Go
+```
+
+Vectors: `Documentation/mesh_vectors.json` (+ identical `python/MCP/` copy) and the
+dependency-free C header `codec/mesh_vectors.gen.h`. The runtime's *timing* is not
+golden-vectored (it is integration-tested); the algorithms and control bytes are.
+
+Live mixed-language mesh (the end-to-end proof — start three nodes, then kill the
+master and watch the survivors re-elect):
+
+```sh
+# master (Go)
+go run ./go/cmd/dcfnode start --mode master --node-id 0 --bind 0.0.0.0:7000 \
+  --peer 1@localhost:7001 --peer 2@localhost:7002
+# auto (Rust)
+cd rust && cargo run -- mesh --mode auto --node-id 1 --bind 0.0.0.0:7001 \
+  --master 0 --peer 0@localhost:7000 --peer 2@localhost:7002
+# auto (Python)
+python3 python/dcf_node.py start --mode auto --node-id 2 --bind 0.0.0.0:7002 \
+  --master 0 --peer 0@localhost:7000 --peer 1@localhost:7001
+```
+
+## 6. Security
+
+DCF-Mesh control is **plaintext**, like the rest of the wire. An on-path observer can
+read the full topology, RTTs, and role assignments from `REPORT`/`ROLE`, and an active
+attacker can forge them (there is no authentication). This is by design for export
+compliance; deploy the mesh inside WireGuard or operator-supplied crypto **beneath**
+the UDP socket. See `DCF_SECURITY_EXPOSURE.md` for the threat model, a runnable
+wiretap demo, and the deployment rule.

--- a/Documentation/DCF_SECURITY_EXPOSURE.md
+++ b/Documentation/DCF_SECURITY_EXPOSURE.md
@@ -1,0 +1,81 @@
+# DCF wire exposure: the plaintext mesh and how to deploy it safely
+
+DCF / HydraMesh is **encryption-free by design**. The core wire — the 17-byte
+`DeModFrame` and the `ProtoMessage` UDP envelope that carries it — contains no
+confidentiality, integrity-against-tampering, or authentication mechanism. This is a
+deliberate, load-bearing decision for EAR/ITAR export compliance
+(`Documentation/Specs/export_compliance.markdown`): a protocol with no cryptography
+is not export-controlled as cryptographic software. **Do not add encryption to the
+core wire path** — doing so changes the export posture of the entire project.
+
+This document states, plainly, what that costs you and how to deploy DCF without
+getting hurt.
+
+## What an on-path observer sees
+
+Because the wire is plaintext, **any party on the network path** — a malicious or
+compromised router, a host with a span/mirror port, anyone on the same broadcast
+segment, a hostile relay — can read and reconstruct, with **zero credentials**:
+
+- **Membership**: which node ids exist, and their addresses.
+- **Topology + latency**: the DCF-Mesh `REPORT` control message carries each node's
+  peer list with per-peer status and RTT — i.e. the live mesh graph and its timing.
+- **Roles / control**: the `ROLE` message reveals who the master is and every node's
+  assigned role. An active attacker can also *forge* `REPORT`/`ROLE` (there is no
+  authentication) to steer election or partition the mesh.
+- **Message contents**: all application payloads — text, positions, game/audio
+  adapter frames — are in the clear.
+
+This is not a bug in any binding; it is the wire. It applies **equally to every
+language node** (Go, C, Rust, Python, …) because they all speak the same plaintext
+envelope. There is nothing to misconfigure and nothing to turn on — an eavesdropper
+just reads it.
+
+### See it for yourself
+
+A passive wiretap is included (Python, stdlib-only):
+
+```sh
+# Terminal 1 — a real mesh node (master)
+python3 python/dcf_node.py start --mode master --node-id 0 --bind 0.0.0.0:7000 \
+    --peer 1@localhost:7001
+
+# Terminal 2 — an auto node that reaches the master *through* the wiretap on :7100
+python3 python/dcf_node.py start --mode auto --node-id 1 --bind 0.0.0.0:7001 \
+    --master 0 --peer 0@localhost:7100
+
+# Terminal 3 — the eavesdropper: capture + forward, decoding everything it sees
+python3 python/dcf_node.py wiretap --bind 0.0.0.0:7100 --forward localhost:7000
+```
+
+Terminal 3 prints the decoded REPORT topology, the ROLE assignments, and any
+application text — none of which it has any right to. A self-contained version is
+`python/examples/wiretap_demo.py`, and the assertion-backed proof (leak **and**
+mitigation) is `python/tests/test_eavesdrop_leak.py`.
+
+## How to deploy it safely
+
+Confidentiality and authentication are **the operator's responsibility, supplied
+outside DCF**, at the transport layer beneath the UDP socket:
+
+- **WireGuard (recommended).** Run every node's DCF traffic inside a WireGuard tunnel
+  (or an equivalent operator-managed VPN / overlay). WireGuard provides modern
+  authenticated encryption, peer authentication, and replay protection; DCF then runs
+  over the encrypted interface and the on-path observer above sees only WireGuard
+  packets. This keeps all cryptography — and its export classification — entirely
+  outside this project.
+- **Operator-supplied, legally-bound crypto.** If you cannot use WireGuard, wrap the
+  datagrams in your own encryption layer that is contractually/legally bound to your
+  deployment and its export obligations — again, *beneath* the DCF socket, as a
+  transport wrapper, never inside the codec or `ProtoMessage`.
+
+The test's `external_wrap` (a one-byte XOR in `python/dcf/wiretap.py`) is **only a
+stand-in** to demonstrate the principle — once the bytes on the wire are no longer a
+DCF `ProtoMessage`, the wiretap decodes nothing. It is not cryptography and must never
+be mistaken for the real mitigation, which is WireGuard or an equivalent.
+
+## The one rule
+
+Keep the DCF wire plaintext; put the crypto in the tunnel under it. That preserves the
+export posture that motivates DCF's design while giving real deployments the
+confidentiality and authentication the bare wire deliberately omits.

--- a/python/dcf/__init__.py
+++ b/python/dcf/__init__.py
@@ -2,6 +2,19 @@
 # Copyright (C) 2025 DeMoD LLC
 # This file is part of DeMoD Communications Framework.
 # Licensed under GPL-3.0 (see LICENSE in repo root).
-from .client import DCFClient, Mode
-from .master import DCFMaster
 __version__ = "5.0.0"
+
+# The gRPC client/master are optional — they need grpc + the generated stubs. The
+# stdlib UDP mesh node below has no such deps, so keep these imports tolerant.
+try:
+    from .client import DCFClient, Mode
+    from .master import DCFMaster
+except ImportError:  # pragma: no cover - grpc not installed
+    DCFClient = Mode = DCFMaster = None
+
+# Stdlib UDP node + self-healing mesh runtime (the interoperable binary-ProtoMessage
+# node, mirroring the Go/C/Rust nodes). No third-party dependencies.
+from .proto import ProtoMessage
+from .udp_node import DcfNode
+from .mesh_runtime import MeshRuntime
+from .wiretap import Wiretap

--- a/python/dcf/mcp_client.py
+++ b/python/dcf/mcp_client.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import time
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx  # For HTTP retries
 from mcp import ClientSession, StdioServerParameters, types

--- a/python/dcf/mesh_runtime.py
+++ b/python/dcf/mesh_runtime.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+"""Self-healing mesh runtime for the Python SDK.
+
+The live counterpart of the certified algorithms in ``python/MCP/meshlab_core.py``,
+and a direct port of ``go/node/mesh_runtime.go`` / ``rust/src/mesh_runtime.rs``. It is
+byte-compatible on the wire (DCF-Mesh REPORT/ROLE carried as a ``MSG_MESH``
+ProtoMessage payload), so a Python node meshes with the Go/C/Rust nodes.
+
+Per ~1s tick: fold each peer's PONG/timeout into a sliding health window
+(``meshlab_core.peer_status``), PING every peer, then by mode:
+  - ``auto``   — REPORT our peer view to the master + decentralized failover.
+  - ``master`` — aggregate reporters' topology, ``meshlab_core.elect``, broadcast ROLE.
+  - ``p2p``    — health FSM only.
+"""
+
+import logging
+import os
+import sys
+import threading
+import time
+
+# The certified primitives live in python/MCP — pure functions, no deps.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "MCP"))
+import meshlab_core as mesh  # noqa: E402
+
+log = logging.getLogger("dcf.mesh")
+
+# Health FSM tuning — identical to the Go/C/Rust runtimes.
+WINDOW_CAP = 5
+FAIL_THR = 3        # consecutive timeouts -> UNREACHABLE
+OK_THR = 2          # consecutive PONGs -> recover from UNREACHABLE
+RELAY_MIN_DEGREE = 2
+TICK_SECONDS = 1.0
+
+
+def _status_name(s):
+    return {mesh.HEALTHY: "healthy", mesh.DEGRADED: "degraded"}.get(s, "unreachable")
+
+
+def _role_name(r):
+    return {mesh.MASTER: "master", mesh.RELAY: "relay"}.get(r, "leaf")
+
+
+class _PeerHealth:
+    __slots__ = ("answered", "window", "status")
+
+    def __init__(self):
+        self.answered = False
+        self.window = []
+        self.status = mesh.HEALTHY
+
+
+class MeshRuntime:
+    """Drives the certified mesh algorithms from live PING/PONG + REPORT/ROLE."""
+
+    def __init__(self, mode, node_id, master_peer="", group_thr=50):
+        self.mode = mode                       # "p2p" | "auto" | "master"
+        self.node_id = int(node_id)
+        self.master_peer = str(master_peer)
+        self.group_thr = max(1, int(group_thr))
+        self.role = mesh.MASTER if mode == "master" else mesh.LEAF
+        self.master = self.node_id if mode == "master" else 0
+
+        self._lock = threading.Lock()
+        self._health = {}                      # peer_id (str) -> _PeerHealth
+        self._reports = {}                     # reporter node id -> [[peer_id,status,rtt],..]
+        self._report_addr = {}                 # reporter node id -> source addr
+        self._thread = None
+        self._running = False
+
+    # ── status helpers ───────────────────────────────────────────────────────
+    def _status_of(self, peer_id):
+        h = self._health.get(str(peer_id))
+        return h.status if h else mesh.HEALTHY
+
+    # ── inbound hooks (called from the node's rx thread) ─────────────────────--
+    def mark_answered(self, peer_id):
+        with self._lock:
+            self._health.setdefault(str(peer_id), _PeerHealth()).answered = True
+
+    def handle_control(self, payload, addr):
+        """Dispatch an incoming DCF-Mesh control message (REPORT or ROLE)."""
+        mtype = mesh.mesh_msg_type(payload)
+        if mtype == mesh.MESH_REPORT:
+            try:
+                nid, peers = mesh.unpack_report(payload)
+            except ValueError:
+                return
+            with self._lock:
+                self._reports[nid] = peers
+                self._report_addr[nid] = addr
+        elif mtype == mesh.MESH_ROLE:
+            try:
+                nid, role, master = mesh.unpack_role(payload)
+            except ValueError:
+                return
+            if nid != self.node_id:
+                return
+            with self._lock:
+                changed = self.role != role or self.master != master
+                self.role, self.master = role, master
+            if changed:
+                log.info("mesh: role assigned -> %s (master %d)", _role_name(role), master)
+
+    # ── per-tick steps ────────────────────────────────────────────────────────
+    def _health_tick(self, peer_ids):
+        with self._lock:
+            for pid in peer_ids:
+                h = self._health.setdefault(pid, _PeerHealth())
+                h.window.append(1 if h.answered else 0)
+                h.answered = False
+                if len(h.window) > WINDOW_CAP:
+                    h.window = h.window[-WINDOW_CAP:]
+                h.status = mesh.peer_status(h.window, FAIL_THR, OK_THR)
+
+    def _send_report(self, node, peer_ids):
+        if not self.master_peer:
+            return
+        with self._lock:
+            peers = []
+            for pid in peer_ids:
+                try:
+                    pint = int(pid)
+                except ValueError:
+                    continue
+                peers.append((pint, self._status_of(pid), node.peer_rtt_ms(pid)))
+        payload = mesh.pack_report(self.node_id, peers)
+        info = node.peer_info(self.master_peer)
+        if info:
+            node.send_mesh(payload, info[0], info[1])
+
+    def _run_election(self, node):
+        # 1. node-id set + deduplicated, canonicalized edges.
+        with self._lock:
+            idset = {self.node_id}
+            dedup = {}
+            for reporter, peers in self._reports.items():
+                idset.add(reporter)
+                for peer_id, status, rtt in peers:
+                    idset.add(peer_id)
+                    if status == mesh.UNREACHABLE:
+                        continue
+                    a, b = (reporter, peer_id) if reporter <= peer_id else (peer_id, reporter)
+                    if (a, b) not in dedup or rtt < dedup[(a, b)]:
+                        dedup[(a, b)] = rtt
+            addrs = dict(self._report_addr)
+
+        # 2. dense 0..N-1 index (sorted, deterministic).
+        ids = sorted(idset)
+        index = {nid: i for i, nid in enumerate(ids)}
+        edges = [[index[a], index[b], w] for (a, b), w in dedup.items()]
+
+        # 3. elect.
+        master_idx, roles = mesh.elect(len(ids), edges, RELAY_MIN_DEGREE)
+        master_id = ids[master_idx]
+
+        # 4. adopt our own role + master.
+        with self._lock:
+            if self.node_id in index:
+                self.role = roles[index[self.node_id]]
+            self.master = master_id
+
+        # 5. unicast each reporter its assigned role.
+        for reporter, addr in addrs.items():
+            if reporter in index:
+                payload = mesh.pack_role(reporter, roles[index[reporter]], master_id)
+                node.send_mesh(payload, addr[0], addr[1])
+
+    def _check_master_failover(self, node, peer_ids):
+        with self._lock:
+            if not self.master_peer or self._status_of(self.master_peer) != mesh.UNREACHABLE:
+                return
+            best = self.node_id
+            for pid in peer_ids:
+                if self._status_of(pid) == mesh.UNREACHABLE:
+                    continue
+                try:
+                    pint = int(pid)
+                except ValueError:
+                    continue
+                if pint < best:
+                    best = pint
+            prev = self.master
+            changed = prev != best
+            self.master = best
+            if best == self.node_id:
+                self.role = mesh.MASTER
+        if changed:
+            log.info("mesh: master %d unreachable -> local re-election, new master %d", prev, best)
+
+    def _log_status(self, node, peer_ids):
+        with self._lock:
+            parts = []
+            for pid in peer_ids:
+                st = self._status_of(pid)
+                grp = mesh.group_of(node.peer_rtt_ms(pid), self.group_thr, st)
+                parts.append("%s:%s:g%d" % (pid, _status_name(st), grp))
+            role, master = self.role, self.master
+        log.info("mesh-status node=%d mode=%s role=%s master=%d peers=[%s]",
+                 self.node_id, self.mode, _role_name(role), master, " ".join(parts))
+
+    # ── loop lifecycle (started by the node) ────────────────────────────────--
+    def start(self, node):
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._run, args=(node,), name="dcf-mesh", daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=2)
+
+    def _run(self, node):
+        tick = 0
+        while self._running and node.is_running():
+            time.sleep(TICK_SECONDS)
+            peers = node.list_peers()
+            self._health_tick(peers)
+            for pid in peers:
+                node.send_ping(pid)
+            if self.mode == "auto":
+                self._send_report(node, peers)
+                self._check_master_failover(node, peers)
+            elif self.mode == "master":
+                self._run_election(node)
+            tick += 1
+            if tick % 3 == 0:
+                self._log_status(node, peers)

--- a/python/dcf/proto.py
+++ b/python/dcf/proto.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+"""Binary ProtoMessage envelope — the UDP transport shared by the Go/C/Rust nodes.
+
+Byte-identical to ``go/node/proto.go`` and ``rust/src/lib.rs`` ``ProtoMessage``:
+a 17-byte big-endian header followed by the payload::
+
+    [0]      msg_type     u8
+    [1:5]    sequence     u32
+    [5:13]   timestamp    u64   (micros since the Unix epoch)
+    [13:17]  payload_len  u32
+    [17:...] payload      payload_len bytes
+
+This is the envelope; adapters (DCF-Game/Audio/Text and the DCF-Mesh REPORT/ROLE
+control) ride inside ``payload``. Stdlib only — no gRPC, no third-party deps.
+"""
+
+import struct
+import time
+
+# Message-type registry — mirrors rust/src/lib.rs `mod msg_type` and go/node/proto.go.
+MSG_POSITION = 1
+MSG_AUDIO = 2
+MSG_GAME_EVENT = 3
+MSG_STATE_SYNC = 4
+MSG_RELIABLE = 5
+MSG_ACK = 6
+MSG_PING = 7
+MSG_PONG = 8
+MSG_GAME_DCF = 9
+MSG_TEXT_DCF = 10
+MSG_MESH = 11  # DCF-Mesh REPORT/ROLE control for the self-healing runtime
+
+HEADER_LEN = 1 + 4 + 8 + 4  # 17
+_HEADER = struct.Struct(">BIQI")  # type, sequence, timestamp, payload_len
+
+
+def now_micros():
+    """Microseconds since the Unix epoch (matches the other SDKs' timestamp)."""
+    return int(time.time() * 1_000_000)
+
+
+class ProtoMessage:
+    """The binary UDP transport envelope."""
+
+    __slots__ = ("msg_type", "sequence", "timestamp", "payload")
+
+    def __init__(self, msg_type, sequence, payload=b"", timestamp=None):
+        self.msg_type = msg_type
+        self.sequence = sequence & 0xFFFFFFFF
+        self.timestamp = now_micros() if timestamp is None else timestamp
+        self.payload = bytes(payload)
+
+    def serialize(self):
+        """Encode to bytes (17-byte big-endian header + payload)."""
+        return _HEADER.pack(self.msg_type, self.sequence, self.timestamp,
+                            len(self.payload)) + self.payload
+
+    @classmethod
+    def deserialize(cls, data):
+        """Parse bytes into a ProtoMessage, or raise ValueError on bad input.
+
+        Guards a short header and a payload-length field that overruns the buffer
+        (mirrors the Go/Rust deserialize guards) — so a wiretap that captures
+        non-DCF (e.g. encrypted) bytes simply fails here.
+        """
+        if len(data) < HEADER_LEN:
+            raise ValueError("message shorter than 17-byte header")
+        msg_type, sequence, timestamp, payload_len = _HEADER.unpack(data[:HEADER_LEN])
+        if len(data) < HEADER_LEN + payload_len:
+            raise ValueError("payload length exceeds message size")
+        payload = data[HEADER_LEN:HEADER_LEN + payload_len]
+        return cls(msg_type, sequence, payload, timestamp=timestamp)
+
+    def __repr__(self):
+        return (f"ProtoMessage(type={self.msg_type}, seq={self.sequence}, "
+                f"ts={self.timestamp}, payload_len={len(self.payload)})")

--- a/python/dcf/udp_node.py
+++ b/python/dcf/udp_node.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+"""Stdlib UDP DcfNode — the interoperable binary-ProtoMessage node for Python.
+
+This is the Python counterpart of the Go/C/Rust nodes (NOT the gRPC ``dcf.client``):
+it speaks the binary :class:`~dcf.proto.ProtoMessage` envelope over UDP, answers
+PING with PONG, tracks per-peer RTT (EMA), and dispatches the DCF-Mesh REPORT/ROLE
+control adapter into the attached :class:`~dcf.mesh_runtime.MeshRuntime`. So a Python
+node meshes with the Go/C/Rust nodes.
+
+Threading: one receive thread + (if a mesh runtime is attached) one tick thread.
+Shared peer state is guarded by a lock.
+"""
+
+import logging
+import socket
+import threading
+
+from .proto import (
+    ProtoMessage,
+    MSG_PING,
+    MSG_PONG,
+    MSG_MESH,
+)
+
+log = logging.getLogger("dcf.udp")
+
+# EMA smoothing factor for RTT — DEFAULT_RTT_ALPHA in the Rust SDK (rust/src/lib.rs).
+RTT_ALPHA = 0.125
+
+
+class DcfNode:
+    """A UDP node bound to ``host:port`` that meshes with the other-language nodes."""
+
+    def __init__(self, host="0.0.0.0", port=7777, node_id="0"):
+        self.host = host
+        self.port = port
+        self.node_id = str(node_id)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((host, port))
+        self._sock.settimeout(0.5)
+
+        self._lock = threading.Lock()
+        self._peers = []                       # ordered peer ids (numeric strings)
+        self._peer_map = {}                    # peer_id -> (host, port)
+        self._peer_rtt = {}                    # peer_id -> smoothed RTT ms (float)
+        self._seq = 0
+        self._running = False
+        self._rx_thread = None
+        self.mesh = None                       # optional MeshRuntime
+
+    # ── peer management ──────────────────────────────────────────────────────
+    def add_peer(self, peer_id, host, port):
+        peer_id = str(peer_id)
+        with self._lock:
+            if peer_id not in self._peer_map:
+                self._peers.append(peer_id)
+            self._peer_map[peer_id] = (host, int(port))
+        log.info("Peer added: %s at %s:%d", peer_id, host, port)
+
+    def list_peers(self):
+        with self._lock:
+            return list(self._peers)
+
+    def peer_info(self, peer_id):
+        with self._lock:
+            return self._peer_map.get(str(peer_id))
+
+    def peer_rtt_ms(self, peer_id):
+        """Smoothed per-peer RTT in whole ms (0 if unknown)."""
+        with self._lock:
+            v = self._peer_rtt.get(str(peer_id), 0.0)
+        return int(v + 0.5) if v > 0 else 0
+
+    def peer_id_by_addr(self, addr):
+        """Resolve a peer id from a source ``(ip, port)`` (match by port, then ip)."""
+        ip, port = addr
+        with self._lock:
+            by_both = None
+            by_port = None
+            for pid, (h, p) in self._peer_map.items():
+                if p == port:
+                    if by_port is None:
+                        by_port = pid
+                    if h == ip or h in ("localhost", "0.0.0.0"):
+                        by_both = pid
+                        break
+            return by_both or by_port
+
+    def _record_rtt(self, peer_id, rtt_ms):
+        with self._lock:
+            prev = self._peer_rtt.get(peer_id, 0.0)
+            self._peer_rtt[peer_id] = RTT_ALPHA * rtt_ms + (1.0 - RTT_ALPHA) * prev
+
+    # ── send ─────────────────────────────────────────────────────────────────
+    def _next_seq(self):
+        with self._lock:
+            self._seq = (self._seq + 1) & 0xFFFFFFFF
+            return self._seq
+
+    def send_message(self, msg, host, port):
+        self._sock.sendto(msg.serialize(), (host, int(port)))
+
+    def send_to(self, msg_type, payload, host, port):
+        self.send_message(ProtoMessage(msg_type, self._next_seq(), payload), host, port)
+
+    def send_ping(self, peer_id):
+        info = self.peer_info(peer_id)
+        if info:
+            self.send_to(MSG_PING, b"", info[0], info[1])
+
+    def send_mesh(self, payload, host, port):
+        self.send_to(MSG_MESH, payload, host, port)
+
+    # ── lifecycle ──────────────────────────────────────────────────────────--
+    def is_running(self):
+        return self._running
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._rx_thread = threading.Thread(target=self._rx_loop, name="dcf-rx", daemon=True)
+        self._rx_thread.start()
+        if self.mesh is not None:
+            self.mesh.start(self)
+
+    def stop(self):
+        self._running = False
+        if self.mesh is not None:
+            self.mesh.stop()
+        if self._rx_thread:
+            self._rx_thread.join(timeout=2)
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+    # ── receive + dispatch ─────────────────────────────────────────────────--
+    def _rx_loop(self):
+        while self._running:
+            try:
+                data, addr = self._sock.recvfrom(65536)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            if not data:
+                continue
+            try:
+                msg = ProtoMessage.deserialize(data)
+            except ValueError as e:
+                log.warning("drop undecodable datagram from %s: %s", addr, e)
+                continue
+            self._dispatch(msg, addr)
+
+    def _dispatch(self, msg, addr):
+        if msg.msg_type == MSG_PING:
+            # Echo the originator's timestamp so it can compute RTT.
+            pong = ProtoMessage(MSG_PONG, msg.sequence, b"", timestamp=msg.timestamp)
+            self._sock.sendto(pong.serialize(), addr)
+        elif msg.msg_type == MSG_PONG:
+            from .proto import now_micros
+            rtt = max(0.0, (now_micros() - msg.timestamp) / 1000.0)
+            pid = self.peer_id_by_addr(addr)
+            if pid:
+                self._record_rtt(pid, rtt)
+                if self.mesh is not None:
+                    self.mesh.mark_answered(pid)
+        elif msg.msg_type == MSG_MESH:
+            if self.mesh is not None:
+                self.mesh.handle_control(msg.payload, addr)
+        else:
+            log.debug("unhandled msg_type %d from %s", msg.msg_type, addr)

--- a/python/dcf/wiretap.py
+++ b/python/dcf/wiretap.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+"""Wiretap — a passive on-path observer for the DCF UDP wire.
+
+The DCF wire is **plaintext by design** (encryption-free for EAR/ITAR export
+compliance — see ``Documentation/Specs/export_compliance.markdown``). The flip side
+is that *any* on-path party — a malicious router, a compromised relay, anyone with a
+span port — can read everything: mesh membership, topology + per-peer RTT (REPORT),
+who is master (ROLE), and message contents. This module makes that exposure concrete.
+
+``Wiretap`` is a transparent UDP relay: it binds a port, **decodes and records**
+every datagram it sees (holding no keys, participating in nothing), then forwards it
+unchanged to the real destination. Point two nodes' peer addresses at the wiretap and
+it reconstructs the whole mesh from the plaintext. See
+``Documentation/DCF_SECURITY_EXPOSURE.md`` and ``python/tests/test_eavesdrop_leak.py``.
+
+The mitigation is to run DCF inside a WireGuard tunnel (or the operator's own,
+export-compliant crypto) layered *under* this UDP socket — never inside the protocol.
+``external_wrap`` below is a deliberately trivial stand-in used only to demonstrate
+that, once the bytes are wrapped outside DCF, the same wiretap recovers nothing.
+"""
+
+import logging
+import os
+import socket
+import sys
+import threading
+
+from .proto import (
+    ProtoMessage,
+    MSG_PING,
+    MSG_PONG,
+    MSG_MESH,
+    MSG_TEXT_DCF,
+    MSG_POSITION,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "MCP"))
+import meshlab_core as mesh  # noqa: E402
+
+log = logging.getLogger("dcf.wiretap")
+
+_TYPE_NAMES = {
+    MSG_PING: "PING", MSG_PONG: "PONG", MSG_MESH: "MESH",
+    MSG_TEXT_DCF: "TEXT", MSG_POSITION: "POSITION",
+}
+
+
+def describe(msg):
+    """Human-readable, fully-decoded summary of a captured ProtoMessage.
+
+    This is the leak: with zero credentials we recover the adapter contents —
+    mesh topology, role assignments, and message payloads — straight from the wire.
+    """
+    name = _TYPE_NAMES.get(msg.msg_type, "type%d" % msg.msg_type)
+    if msg.msg_type == MSG_MESH:
+        mtype = mesh.mesh_msg_type(msg.payload)
+        if mtype == mesh.MESH_REPORT:
+            try:
+                nid, peers = mesh.unpack_report(msg.payload)
+                view = ", ".join("peer%d=%s/%dms" % (p, _st(s), r) for p, s, r in peers)
+                return "MESH/REPORT node=%d peers=[%s]" % (nid, view)
+            except ValueError:
+                pass
+        elif mtype == mesh.MESH_ROLE:
+            try:
+                nid, role, master = mesh.unpack_role(msg.payload)
+                return "MESH/ROLE node=%d role=%s master=%d" % (nid, _role(role), master)
+            except ValueError:
+                pass
+        return "MESH/?? %r" % (msg.payload,)
+    if msg.payload:
+        # Best-effort: many adapters carry UTF-8 text; show it if printable.
+        try:
+            txt = msg.payload.decode("utf-8")
+            if txt.isprintable():
+                return "%s text=%r" % (name, txt)
+        except UnicodeDecodeError:
+            pass
+        return "%s payload=%s" % (name, msg.payload.hex())
+    return name
+
+
+def _st(s):
+    return {mesh.HEALTHY: "healthy", mesh.DEGRADED: "degraded"}.get(s, "unreachable")
+
+
+def _role(r):
+    return {mesh.MASTER: "master", mesh.RELAY: "relay"}.get(r, "leaf")
+
+
+def external_wrap(data, key=0x5A):
+    """Stand-in for an external transport encryptor (e.g. WireGuard).
+
+    A single-byte XOR is obviously NOT real crypto — it is only here to model
+    "the bytes on the wire are no longer a DCF ProtoMessage". In production this is
+    WireGuard, applied beneath the UDP socket, entirely outside DCF. Do NOT add this
+    (or any crypto) to the DCF core wire path.
+    """
+    return bytes(b ^ key for b in data)
+
+
+# external_wrap is its own inverse (XOR), so unwrap == wrap.
+external_unwrap = external_wrap
+
+
+class Wiretap:
+    """Transparent capturing UDP relay. Forwards ``bind`` -> ``forward``."""
+
+    def __init__(self, bind, forward, on_capture=None, label="wiretap"):
+        self.forward = (forward[0], int(forward[1]))
+        self.label = label
+        self.on_capture = on_capture
+        self.captures = []                     # list of (raw_bytes, src_addr)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((bind[0], int(bind[1])))
+        self._sock.settimeout(0.5)
+        self._running = False
+        self._thread = None
+
+    def start(self):
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, name=self.label, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=2)
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+    def _loop(self):
+        while self._running:
+            try:
+                data, src = self._sock.recvfrom(65536)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            self.captures.append((data, src))
+            try:
+                msg = ProtoMessage.deserialize(data)
+                summary = describe(msg)
+            except ValueError:
+                summary = "<undecodable: %d bytes>" % len(data)
+            log.info("[%s] %s -> %s : %s", self.label, src, self.forward, summary)
+            if self.on_capture:
+                self.on_capture(data, src, summary)
+            # Forward unchanged — a passive tap is transparent to the mesh.
+            try:
+                self._sock.sendto(data, self.forward)
+            except OSError:
+                pass
+
+    def decoded(self):
+        """All captures that decode as a DCF ProtoMessage (the recovered plaintext)."""
+        out = []
+        for data, src in self.captures:
+            try:
+                out.append(ProtoMessage.deserialize(data))
+            except ValueError:
+                continue
+        return out

--- a/python/dcf_node.py
+++ b/python/dcf_node.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-only
+"""dcf_node — the stdlib UDP self-healing mesh node CLI for Python.
+
+Mirrors ``go/cmd/dcfnode`` and the Rust ``dcf mesh`` subcommand, speaking the binary
+ProtoMessage wire so it meshes with the Go/C/Rust nodes::
+
+    python3 python/dcf_node.py start --bind 0.0.0.0:7002 --mode auto --node-id 2 \\
+        --master 0 --peer 0@localhost:7000 --peer 1@localhost:7001
+
+A passive eavesdropper for the (encryption-free) wire — demonstrates the data-leak
+exposure that motivates a WireGuard tunnel (see Documentation/DCF_SECURITY_EXPOSURE.md)::
+
+    python3 python/dcf_node.py wiretap --bind 0.0.0.0:7100 --forward localhost:7000
+"""
+
+import argparse
+import logging
+import sys
+import time
+
+# Allow running as a script from anywhere (python3 python/dcf_node.py ...).
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+from dcf.udp_node import DcfNode
+from dcf.mesh_runtime import MeshRuntime
+from dcf.wiretap import Wiretap
+
+
+def _split_hostport(s, what):
+    host, _, port = s.rpartition(":")
+    if not host or not port:
+        raise SystemExit("error: %s expects host:port, got %r" % (what, s))
+    return host, int(port)
+
+
+def _parse_peer(spec):
+    if "@" not in spec:
+        raise SystemExit("error: --peer expects id@host:port, got %r" % spec)
+    pid, addr = spec.split("@", 1)
+    host, port = _split_hostport(addr, "--peer")
+    return pid, host, port
+
+
+def cmd_start(args):
+    host, port = _split_hostport(args.bind, "--bind")
+    node = DcfNode(host=host, port=port, node_id=args.node_id)
+    for spec in args.peer or []:
+        node.add_peer(*_parse_peer(spec))
+    if args.mode != "p2p" or args.peer:
+        node.mesh = MeshRuntime(args.mode, args.node_id, args.master, args.group_threshold)
+    logging.info("self-healing mesh: mode=%s node-id=%s master=%r listening on %s:%d",
+                 args.mode, args.node_id, args.master, host, port)
+    node.start()
+    logging.info("dcf mesh node ready (Ctrl-C to stop)")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logging.info("shutting down")
+    finally:
+        node.stop()
+
+
+def cmd_wiretap(args):
+    bind = _split_hostport(args.bind, "--bind")
+    forward = _split_hostport(args.forward, "--forward")
+    tap = Wiretap(bind, forward, label="wiretap")
+    logging.info("wiretap: capturing %s -> %s (plaintext DCF wire; Ctrl-C to stop)",
+                 args.bind, args.forward)
+    tap.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logging.info("captured %d datagrams", len(tap.captures))
+    finally:
+        tap.stop()
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(prog="dcf_node", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="command", required=True)
+
+    s = sub.add_parser("start", help="run a self-healing mesh node")
+    s.add_argument("--bind", default="0.0.0.0:7777", help="bind address host:port")
+    s.add_argument("--mode", default="p2p", choices=["p2p", "auto", "master"])
+    s.add_argument("--node-id", default="0", help="this node's numeric mesh id")
+    s.add_argument("--master", default="", help="peer id to REPORT to (auto mode)")
+    s.add_argument("--peer", action="append", metavar="ID@HOST:PORT",
+                   help="peer (repeatable)")
+    s.add_argument("--group-threshold", type=int, default=50,
+                   help="RTT threshold (ms) for status-line grouping")
+    s.set_defaults(func=cmd_start)
+
+    w = sub.add_parser("wiretap", help="passively capture + forward the plaintext wire")
+    w.add_argument("--bind", required=True, help="listen address host:port")
+    w.add_argument("--forward", required=True, help="real destination host:port")
+    w.set_defaults(func=cmd_wiretap)
+
+    args = p.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/wiretap_demo.py
+++ b/python/examples/wiretap_demo.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-only
+"""Live demo: a passive wiretap reconstructs an encryption-free DCF mesh.
+
+Spins up a 2-node mesh (a master + an auto node) whose peer traffic is routed through
+a :class:`~dcf.wiretap.Wiretap`. The wiretap holds no credentials and participates in
+nothing, yet it decodes and prints the full plaintext stream: PING/PONG liveness, the
+auto node's REPORT (its peer view + RTT), and the master's ROLE assignment. That is
+the leak the encryption-free wire exposes to any on-path party.
+
+Run::
+
+    python3 python/examples/wiretap_demo.py
+
+Then read ``Documentation/DCF_SECURITY_EXPOSURE.md``: the fix is to run DCF inside a
+WireGuard tunnel (or the operator's own export-compliant crypto), beneath this socket.
+"""
+
+import logging
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from dcf.udp_node import DcfNode
+from dcf.mesh_runtime import MeshRuntime
+from dcf.wiretap import Wiretap
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+
+    # Ports: master=7000, auto=7001, and a wiretap on 7100 that forwards to the master.
+    master = DcfNode("127.0.0.1", 7000, node_id="0")
+    master.mesh = MeshRuntime("master", 0, "", group_thr=50)
+
+    auto = DcfNode("127.0.0.1", 7001, node_id="1")
+    auto.mesh = MeshRuntime("auto", 1, master_peer="0", group_thr=50)
+
+    # The auto node reaches the master *through* the wiretap (a malicious on-path hop).
+    tap = Wiretap(("127.0.0.1", 7100), ("127.0.0.1", 7000), label="EVE")
+    auto.add_peer("0", "127.0.0.1", 7100)   # auto -> master via the tap
+    master.add_peer("1", "127.0.0.1", 7001)  # master -> auto direct (replies still seen)
+
+    tap.start()
+    master.start()
+    auto.start()
+    logging.info("running 2-node mesh through wiretap EVE for ~6s ...")
+    try:
+        time.sleep(6)
+    finally:
+        auto.stop()
+        master.stop()
+        tap.stop()
+
+    decoded = tap.decoded()
+    logging.info("EVE captured %d datagrams, %d decoded as DCF (zero credentials)",
+                 len(tap.captures), len(decoded))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+# Confine rootdir/config to the SDK so pytest does not climb to a stray parent
+# pyproject.toml. importlib import mode avoids the parent-__init__ package walk.
+testpaths = tests
+addopts = --import-mode=importlib
+consider_namespace_packages = false

--- a/python/tests/test_eavesdrop_leak.py
+++ b/python/tests/test_eavesdrop_leak.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+"""Data-leak demonstration: the encryption-free DCF wire is fully readable on-path.
+
+DCF is plaintext by design (EAR/ITAR export compliance). This test *proves* the
+consequence: a passive :class:`~dcf.wiretap.Wiretap` holding no credentials, sitting
+on the path between two real mesh nodes, recovers the entire mesh from the wire —
+membership + topology + RTT (REPORT), the master assignment (ROLE), and message
+contents. It then shows the mitigation: wrapping each datagram with an *external*
+transport encryptor (modeling WireGuard, applied outside DCF) leaves the same wiretap
+with nothing to decode.
+
+The wrapper here is a trivial XOR stand-in living only in the demo — NOT crypto, and
+never in the DCF core wire path. In production the wrapper is WireGuard. See
+Documentation/DCF_SECURITY_EXPOSURE.md.
+"""
+
+import os
+import socket
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "MCP"))
+
+import meshlab_core as mesh
+from dcf.proto import ProtoMessage, MSG_TEXT_DCF, MSG_MESH
+from dcf.udp_node import DcfNode
+from dcf.mesh_runtime import MeshRuntime
+from dcf.wiretap import Wiretap, describe, external_wrap, external_unwrap
+
+SECRET = "rendezvous@145.500MHz: extraction at 0300"
+
+
+def _find(decoded, msg_type, pred):
+    for m in decoded:
+        if m.msg_type == msg_type and pred(m):
+            return m
+    return None
+
+
+def test_passive_wiretap_reconstructs_plaintext_mesh():
+    # A master (node 0) and an auto node (node 1). The auto node reaches the master
+    # *through* a wiretap on :7100 — a malicious on-path hop.
+    master = DcfNode("127.0.0.1", 7000, node_id="0")
+    master.mesh = MeshRuntime("master", 0, "", group_thr=50)
+    auto = DcfNode("127.0.0.1", 7001, node_id="1")
+    auto.mesh = MeshRuntime("auto", 1, master_peer="0", group_thr=50)
+
+    tap = Wiretap(("127.0.0.1", 7100), ("127.0.0.1", 7000), label="EVE")
+    auto.add_peer("0", "127.0.0.1", 7100)    # auto -> master via the tap
+    master.add_peer("1", "127.0.0.1", 7001)  # master -> auto direct
+
+    tap.start()
+    master.start()
+    auto.start()
+    try:
+        # A "secret" application message crossing the same plaintext wire.
+        for _ in range(3):
+            auto.send_to(MSG_TEXT_DCF, SECRET.encode(), "127.0.0.1", 7100)
+            time.sleep(0.3)
+
+        # Wait (<= ~8s) until the tap has captured a REPORT, a ROLE, and the text.
+        report = role = text = None
+        deadline = time.time() + 8
+        while time.time() < deadline:
+            decoded = tap.decoded()
+            report = _find(decoded, MSG_MESH,
+                           lambda m: mesh.mesh_msg_type(m.payload) == mesh.MESH_REPORT)
+            role = _find(decoded, MSG_MESH,
+                         lambda m: mesh.mesh_msg_type(m.payload) == mesh.MESH_ROLE)
+            text = _find(decoded, MSG_TEXT_DCF, lambda m: SECRET.encode() in m.payload)
+            if report and role and text:
+                break
+            time.sleep(0.3)
+    finally:
+        auto.stop()
+        master.stop()
+        tap.stop()
+
+    # --- THE LEAK: EVE, with zero credentials, reconstructs everything. ---
+    assert text is not None, "eavesdropper did not capture the application message"
+    assert SECRET in text.payload.decode(), "secret message recovered verbatim"
+
+    assert report is not None, "eavesdropper did not capture a REPORT"
+    nid, peers = mesh.unpack_report(report.payload)
+    assert nid == 1                                   # learned the reporting node id
+    assert any(p[0] == 0 for p in peers)              # learned its peer (the master)
+    # describe() is what the live CLI prints — confirm it spells out the topology.
+    assert "REPORT" in describe(report)
+
+    assert role is not None, "eavesdropper did not capture a ROLE"
+    _rnid, _role, master_id = mesh.unpack_role(role.payload)
+    assert master_id == 0                             # learned who the master is
+
+
+def test_external_wrap_defeats_the_wiretap():
+    # The exact bytes a node would put on the wire for a REPORT.
+    report = ProtoMessage(MSG_MESH, 1,
+                          mesh.pack_report(1, [(0, mesh.HEALTHY, 12)])).serialize()
+
+    # Plaintext on the wire -> the wiretap decodes it (the leak).
+    assert ProtoMessage.deserialize(report).msg_type == MSG_MESH
+
+    # Wrapped by an external transport encryptor (WireGuard stand-in) -> on the wire
+    # it is no longer a DCF ProtoMessage, so the wiretap recovers nothing.
+    on_wire = external_wrap(report)
+    assert on_wire != report
+    try:
+        ProtoMessage.deserialize(on_wire)
+        decoded_ok = True
+    except ValueError:
+        decoded_ok = False
+    assert not decoded_ok, "external wrapper must make the datagram undecodable to a tap"
+
+    # Drive it through an actual Wiretap to confirm it logs/recovers nothing usable.
+    sink = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sink.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sink.bind(("127.0.0.1", 7202))
+    tap = Wiretap(("127.0.0.1", 7201), ("127.0.0.1", 7202), label="EVE")
+    tap.start()
+    try:
+        tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        for _ in range(3):
+            tx.sendto(on_wire, ("127.0.0.1", 7201))
+            time.sleep(0.1)
+        time.sleep(0.5)
+    finally:
+        tap.stop()
+        sink.close()
+    assert len(tap.captures) >= 1                      # bytes did cross the wire
+    assert tap.decoded() == []                         # ...but none decode as DCF
+
+    # The legitimate endpoint, holding the key, still recovers the frame.
+    assert external_unwrap(on_wire) == report
+    assert ProtoMessage.deserialize(external_unwrap(on_wire)).msg_type == MSG_MESH

--- a/python/tests/test_mesh_runtime.py
+++ b/python/tests/test_mesh_runtime.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+"""Unit tests for the Python self-healing mesh runtime + binary envelope.
+
+The certified primitives themselves are pinned by python/MCP/gen_mesh_vectors.py;
+these tests cover the *runtime* wiring (FSM window, control dispatch) and the
+ProtoMessage envelope round-trip.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "MCP"))
+
+import meshlab_core as mesh
+from dcf.proto import ProtoMessage, MSG_MESH, HEADER_LEN
+from dcf.mesh_runtime import MeshRuntime
+
+
+def _tick(rt, peers, n, answered=False):
+    for _ in range(n):
+        if answered:
+            for p in peers:
+                rt.mark_answered(p)
+        rt._health_tick(peers)
+
+
+def test_fsm_window_unreachable_then_recovers():
+    rt = MeshRuntime("auto", 1, "0", 50)
+    peers = ["2"]
+    _tick(rt, peers, 3, answered=False)          # 3 timeouts -> UNREACHABLE
+    assert rt._status_of("2") == mesh.UNREACHABLE
+    _tick(rt, peers, 2, answered=True)           # 2 PONGs -> recover
+    assert rt._status_of("2") == mesh.HEALTHY
+
+
+def test_degraded_after_single_timeout():
+    rt = MeshRuntime("auto", 1, "0", 50)
+    peers = ["2"]
+    _tick(rt, peers, 1, answered=True)           # ok
+    _tick(rt, peers, 1, answered=False)          # one timeout -> DEGRADED
+    assert rt._status_of("2") == mesh.DEGRADED
+
+
+def test_role_adoption_via_control():
+    rt = MeshRuntime("auto", 7, "0", 50)
+    payload = mesh.pack_role(7, mesh.RELAY, 3)
+    rt.handle_control(payload, ("127.0.0.1", 9000))
+    assert rt.role == mesh.RELAY
+    assert rt.master == 3
+    # A ROLE addressed to a different node is ignored.
+    rt.handle_control(mesh.pack_role(99, mesh.MASTER, 99), ("127.0.0.1", 9000))
+    assert rt.master == 3
+
+
+def test_master_records_reports():
+    rt = MeshRuntime("master", 0, "", 50)
+    report = mesh.pack_report(1, [(0, mesh.HEALTHY, 12), (2, mesh.HEALTHY, 20)])
+    rt.handle_control(report, ("127.0.0.1", 7001))
+    assert 1 in rt._reports
+    assert rt._report_addr[1] == ("127.0.0.1", 7001)
+
+
+def test_protomessage_roundtrip():
+    msg = ProtoMessage(MSG_MESH, 42, b"hello-wire")
+    raw = msg.serialize()
+    assert len(raw) == HEADER_LEN + len(b"hello-wire")
+    back = ProtoMessage.deserialize(raw)
+    assert back.msg_type == MSG_MESH
+    assert back.sequence == 42
+    assert back.timestamp == msg.timestamp
+    assert back.payload == b"hello-wire"
+
+
+def test_protomessage_rejects_short_and_overrun():
+    import pytest
+    with pytest.raises(ValueError):
+        ProtoMessage.deserialize(b"\x00\x01\x02")          # < 17 bytes
+    truncated = ProtoMessage(MSG_MESH, 1, b"abcdef").serialize()[:-2]
+    with pytest.raises(ValueError):
+        ProtoMessage.deserialize(truncated)                 # payload overruns

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "dcf-rust-sdk"
-version = "2.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "dcf-wire-codec"
-version = "1.0.0"
+version = "0.3.0"
 dependencies = [
  "cc",
  "serde",

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
-use std::net::{SocketAddr, UdpSocket};
+use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -45,6 +45,13 @@ pub fn reassemble_audio_payload(
     let frame: [u8; 17] = payload.try_into().ok()?;
     reasm.push(&frame)
 }
+
+/// DCF-Mesh: the self-healing runtime (peer health FSM + AUTO/master role
+/// assignment + decentralized failover), driving the certified
+/// `dcf_wire_codec::mesh` algorithms from live PING/PONG + the REPORT/ROLE control
+/// adapter. Meshes with the Go and C nodes. See [`MeshRuntime`].
+pub mod mesh_runtime;
+pub use mesh_runtime::MeshRuntime;
 
 /// DCF-Game: multiplayer state/events over the DeModFrame wire (re-exported codec).
 /// Provides `packetize`, `GameReassembler`, body packers, etc. See DCF_GAME_SPEC.md.
@@ -340,9 +347,21 @@ impl UdpEndpoint {
     }
 
     pub fn send_message(&self, msg: &ProtoMessage, host: &str, port: u16, reliable: bool) -> Result<()> {
-        let addr: SocketAddr = format!("{}:{}", host, port).parse()
-            .map_err(|e| DcfError::Network(format!("Invalid address: {}", e)))?;
-        
+        // Resolve via getaddrinfo so hostname peers (e.g. "localhost", Docker
+        // container names) work, not just IP literals — `SocketAddr::parse` rejects
+        // hostnames. Prefer an IPv4 result since the node socket binds IPv4 (else a
+        // host that resolves to ::1 first is unreachable). Matches the Go node.
+        let resolved: Vec<SocketAddr> = (host, port)
+            .to_socket_addrs()
+            .map_err(|e| DcfError::Network(format!("resolve {}:{}: {}", host, port, e)))?
+            .collect();
+        let addr: SocketAddr = resolved
+            .iter()
+            .find(|a| a.is_ipv4())
+            .or_else(|| resolved.first())
+            .copied()
+            .ok_or_else(|| DcfError::Network(format!("no address for {}:{}", host, port)))?;
+
         let data = msg.serialize();
         
         if reliable {
@@ -554,6 +573,8 @@ pub struct DcfNode {
     role: Arc<RwLock<String>>,
     master_address: Arc<RwLock<String>>,
     tx_cache: Arc<Mutex<HashMap<String, TxContext>>>,
+    /// Optional self-healing mesh runtime, attached via [`DcfNode::enable_mesh`].
+    mesh: Arc<Mutex<Option<Arc<MeshRuntime>>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -587,6 +608,7 @@ impl DcfNode {
             role: Arc::new(RwLock::new("p2p".to_string())),
             master_address: Arc::new(RwLock::new(String::new())),
             tx_cache: Arc::new(Mutex::new(HashMap::new())),
+            mesh: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -650,25 +672,61 @@ impl DcfNode {
             .collect()
     }
 
-    /// Resolve the peer_id for a source address (matched by port, then ip) and fold
-    /// a fresh RTT sample into its per-peer stats. Called from the PONG handler.
+    /// Resolve the peer_id for a source address (matched by port, then ip). Shared by
+    /// the PONG RTT path and the mesh runtime's PONG->mark_answered hook.
+    pub(crate) fn peer_id_by_addr(&self, from: SocketAddr) -> Option<String> {
+        let map = self.peer_map.read();
+        map.iter()
+            .find(|(_, (host, port))| {
+                *port == from.port()
+                    && (host == &from.ip().to_string()
+                        || host == "localhost"
+                        || host == "0.0.0.0")
+            })
+            .or_else(|| map.iter().find(|(_, (_, port))| *port == from.port()))
+            .map(|(id, _)| id.clone())
+    }
+
+    /// Smoothed per-peer RTT in whole milliseconds (0 if unknown). Used by the mesh
+    /// runtime for REPORT weights and status-line grouping.
+    pub(crate) fn peer_rtt_ms(&self, id: &str) -> i32 {
+        match self.per_peer_stats.read().get(id) {
+            Some(s) if s.avg_rtt > 0.0 => (s.avg_rtt + 0.5) as i32,
+            _ => 0,
+        }
+    }
+
+    /// Resolve the peer_id for a source address and fold a fresh RTT sample into its
+    /// per-peer stats. Called from the PONG handler.
     fn record_peer_rtt(&self, from: SocketAddr, rtt_ms: f64) {
-        let peer_id = {
-            let map = self.peer_map.read();
-            map.iter()
-                .find(|(_, (host, port))| {
-                    *port == from.port()
-                        && (host == &from.ip().to_string()
-                            || host == "localhost"
-                            || host == "0.0.0.0")
-                })
-                .or_else(|| map.iter().find(|(_, (_, port))| *port == from.port()))
-                .map(|(id, _)| id.clone())
-        };
-        if let Some(id) = peer_id {
+        if let Some(id) = self.peer_id_by_addr(from) {
             let mut stats = self.per_peer_stats.write();
             stats.entry(id).or_default().update_rtt(rtt_ms);
         }
+    }
+
+    /// Send a DCF-Mesh control payload (REPORT/ROLE) as a `MsgMesh` ProtoMessage.
+    pub(crate) fn send_mesh(&self, payload: Vec<u8>, host: &str, port: u16) {
+        if let Some(ep) = &self.udp_endpoint {
+            let msg = ProtoMessage::new(msg_type::MESH, self.next_sequence(), payload);
+            let _ = ep.send_message(&msg, host, port, false);
+        }
+    }
+
+    /// As [`Self::send_mesh`], addressed by `SocketAddr` (master ROLE unicast).
+    pub(crate) fn send_mesh_addr(&self, payload: Vec<u8>, addr: SocketAddr) {
+        self.send_mesh(payload, &addr.ip().to_string(), addr.port());
+    }
+
+    /// Attach a self-healing mesh runtime. Spawn its loop via [`run_mesh_runtime`]
+    /// after [`Self::start`]. `mode` is "p2p" | "auto" | "master".
+    pub fn enable_mesh(&self, mode: &str, node_id: u16, master_peer: &str, group_thr: i32) {
+        *self.mesh.lock() = Some(Arc::new(MeshRuntime::new(mode, node_id, master_peer, group_thr)));
+    }
+
+    /// The attached mesh runtime, if any.
+    pub fn mesh(&self) -> Option<Arc<MeshRuntime>> {
+        self.mesh.lock().clone()
     }
 
     // ========================================================================
@@ -1190,6 +1248,15 @@ pub async fn run_ping_scheduler(node: Arc<DcfNode>, every: Duration) {
     }
 }
 
+/// Spawn the attached self-healing mesh runtime's tick loop (no-op if none). The
+/// loop drives its own per-tick PINGs, so do not also run [`run_ping_scheduler`]
+/// when the mesh runtime is active. Call after [`DcfNode::start`].
+pub fn run_mesh_runtime(node: Arc<DcfNode>) {
+    if let Some(m) = node.mesh() {
+        tokio::spawn(async move { m.run(node).await });
+    }
+}
+
 pub async fn run_udp_receiver(
     node: Arc<DcfNode>,
     handler: Arc<dyn MessageHandler>,
@@ -1262,6 +1329,18 @@ async fn handle_incoming_message(
             let rtt = (now.saturating_sub(msg.timestamp)) as f64 / 1000.0;
             endpoint.stats.write().update_rtt(rtt);
             node.record_peer_rtt(from, rtt);
+            // Feed the mesh runtime's liveness FSM.
+            if let Some(m) = node.mesh() {
+                if let Some(id) = node.peer_id_by_addr(from) {
+                    m.mark_answered(&id);
+                }
+            }
+        }
+        msg_type::MESH => {
+            // DCF-Mesh control (REPORT/ROLE) for the self-healing runtime.
+            if let Some(m) = node.mesh() {
+                m.handle_control(&msg.payload, from);
+            }
         }
         msg_type::RELIABLE => {
             let _ = endpoint.send_ack(msg.sequence, &from);

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -20,7 +20,7 @@ use tokio::net::UdpSocket;
 use dcf_rust_sdk::{
     DcfConfig, DcfNode, DcfError, Result,
     MyDcfService, DefaultMessageHandler,
-    run_udp_receiver, run_reliable_handler,
+    run_udp_receiver, run_reliable_handler, run_mesh_runtime,
     Position, GameEvent, MessageHandler,
 };
 use dcf_rust_sdk::proto::dcf_service_server::DcfServiceServer;
@@ -145,6 +145,26 @@ enum Commands {
     
     /// Show detailed help information
     Info,
+
+    /// Run as a self-healing mesh node (peer health FSM + AUTO/master role
+    /// assignment + decentralized failover). Meshes with the Go/C/Python nodes.
+    Mesh {
+        /// Bind address host:port (defaults to the config udp_port on 0.0.0.0)
+        #[arg(long)]
+        bind: Option<String>,
+        /// Mesh mode: p2p | auto | master
+        #[arg(long, default_value = "p2p")]
+        mode: String,
+        /// This node's numeric mesh id (u16; required for auto/master)
+        #[arg(long, default_value_t = 0)]
+        node_id: u16,
+        /// Peer id to REPORT to (auto mode)
+        #[arg(long, default_value = "")]
+        master: String,
+        /// Peer as id@host:port (repeatable)
+        #[arg(long)]
+        peer: Vec<String>,
+    },
 }
 
 // ============================================================================
@@ -216,6 +236,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
         Some(Commands::Info) => {
             print_info();
+            return Ok(());
+        }
+        Some(Commands::Mesh { bind, mode, node_id, master, peer }) => {
+            run_mesh(&cli.config, bind.clone(), mode, *node_id, master, peer).await?;
             return Ok(());
         }
         _ => {}
@@ -306,6 +330,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             println!("{{\"status\": \"transaction-rolled-back\", \"tx_id\": \"{}\"}}", tx_id);
         }
         Some(Commands::Info) => unreachable!(),
+        Some(Commands::Mesh { .. }) => unreachable!(),
     }
 
     Ok(())
@@ -436,6 +461,67 @@ async fn run_server(
     playback_task.abort();
     shim_listener_task.abort();
 
+    Ok(())
+}
+
+// ============================================================================
+// Self-healing mesh node
+// ============================================================================
+
+/// Parse a `id@host:port` peer spec.
+fn parse_peer_spec(s: &str) -> std::result::Result<(String, String, u16), String> {
+    let (id, addr) = s.split_once('@').ok_or_else(|| format!("expected id@host:port, got {:?}", s))?;
+    let (host, port) = addr.rsplit_once(':').ok_or_else(|| format!("expected host:port, got {:?}", addr))?;
+    let port: u16 = port.parse().map_err(|_| format!("bad port in {:?}", s))?;
+    Ok((id.to_string(), host.to_string(), port))
+}
+
+/// Run as a self-healing mesh node until Ctrl-C. Mirrors `go/cmd/dcfnode start`.
+async fn run_mesh(
+    config_path: &str,
+    bind: Option<String>,
+    mode: &str,
+    node_id: u16,
+    master: &str,
+    peers: &[String],
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let mut config = load_config(config_path)?;
+    config.transport = "UDP".to_string();
+    config.node_id = Some(node_id.to_string());
+    if let Some(b) = bind {
+        let (host, port) = b.rsplit_once(':').ok_or("--bind expects host:port")?;
+        config.host = host.to_string();
+        config.udp_port = port.parse().map_err(|_| "bad --bind port")?;
+    }
+    let group_thr = config.group_rtt_threshold as i32;
+
+    let node = Arc::new(DcfNode::new(config)?);
+    for ps in peers {
+        let (id, host, port) = parse_peer_spec(ps).map_err(|e| format!("--peer {}: {}", ps, e))?;
+        node.add_peer(&id, &host, port)?;
+    }
+    node.enable_mesh(mode, node_id, master, group_thr);
+    node.start()?;
+    log::info!(
+        "self-healing mesh: mode={} node-id={} master={:?} listening on {}:{}",
+        mode, node_id, master, node.config().host, node.config().udp_port
+    );
+
+    // UDP receiver (drives PING/PONG + MsgMesh dispatch) + the mesh tick loop.
+    let recv_node = node.clone();
+    let handler = Arc::new(DefaultMessageHandler) as Arc<dyn MessageHandler>;
+    let recv_task = tokio::spawn(async move {
+        if let Err(e) = run_udp_receiver(recv_node, handler).await {
+            log::error!("UDP receiver error: {}", e);
+        }
+    });
+    run_mesh_runtime(node.clone());
+
+    log::info!("dcf mesh node ready (Ctrl-C to stop)");
+    tokio::signal::ctrl_c().await?;
+    log::info!("shutting down");
+    node.stop()?;
+    recv_task.abort();
     Ok(())
 }
 

--- a/rust/src/mesh_runtime.rs
+++ b/rust/src/mesh_runtime.rs
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//! Self-healing mesh runtime for the Rust SDK — the live counterpart of the
+//! certified algorithms in `dcf_wire_codec::mesh`. A direct port of
+//! `go/node/mesh_runtime.go` and `C_SDK/node/dcf_mesh_runtime.h`, byte-compatible
+//! on the wire (DCF-Mesh REPORT/ROLE carried as a `MsgMesh` ProtoMessage payload),
+//! so a Rust node meshes with the Go and C nodes.
+//!
+//! Per ~1s tick: fold each peer's PONG/timeout into a sliding health window
+//! (`mesh::peer_status`), PING every peer, then by mode:
+//!   - `auto`   — REPORT our peer view to the master + decentralized failover.
+//!   - `master` — aggregate reporters' topology, `mesh::elect`, broadcast ROLE.
+//!   - `p2p`    — health FSM only.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+
+use dcf_wire_codec::mesh;
+
+use crate::DcfNode;
+
+// Health FSM tuning — identical to the Go/C runtimes.
+const MESH_WINDOW_CAP: usize = 5; // sliding health-window size
+const MESH_FAIL_THR: i32 = 3; // consecutive timeouts -> Unreachable
+const MESH_OK_THR: i32 = 2; // consecutive PONGs -> recover from Unreachable
+const MESH_RELAY_MIN_DEGREE: i32 = 2; // healthy degree required for a Relay role
+
+/// Per-peer liveness state, advanced once per tick.
+#[derive(Default)]
+struct PeerHealth {
+    answered: bool,  // set true by a PONG, consumed (reset) each tick
+    window: Vec<u8>, // last <=MESH_WINDOW_CAP events (1 = ok, 0 = timeout)
+    status: i32,     // mesh::HEALTHY | DEGRADED | UNREACHABLE
+}
+
+/// Mutable runtime state behind a single lock.
+struct Inner {
+    role: i32,
+    master: u16,
+    health: HashMap<String, PeerHealth>,
+    // master-side aggregation: reporter node id -> its reported [peer_id, status, rtt]
+    reports: HashMap<u16, Vec<[i32; 3]>>,
+    // master-side: reporter node id -> source addr, for unicasting ROLE back
+    report_addr: HashMap<u16, SocketAddr>,
+}
+
+/// The self-healing mesh runtime. Construct via [`DcfNode::enable_mesh`].
+pub struct MeshRuntime {
+    mode: String,        // "p2p" | "auto" | "master"
+    node_id: u16,        // this node's numeric mesh id
+    master_peer: String, // peer id (string) to REPORT to, in auto mode
+    group_thr: i32,      // RTT threshold for the status-line group id
+    inner: Mutex<Inner>,
+}
+
+fn status_name(s: i32) -> &'static str {
+    match s {
+        mesh::HEALTHY => "healthy",
+        mesh::DEGRADED => "degraded",
+        _ => "unreachable",
+    }
+}
+
+fn role_name(r: i32) -> &'static str {
+    match r {
+        mesh::MASTER => "master",
+        mesh::RELAY => "relay",
+        _ => "leaf",
+    }
+}
+
+impl MeshRuntime {
+    /// Build a runtime. A `master` node starts as MASTER of itself; others as LEAF.
+    pub fn new(mode: &str, node_id: u16, master_peer: &str, group_thr: i32) -> Self {
+        let (role, master) = if mode == "master" {
+            (mesh::MASTER, node_id)
+        } else {
+            (mesh::LEAF, 0)
+        };
+        MeshRuntime {
+            mode: mode.to_string(),
+            node_id,
+            master_peer: master_peer.to_string(),
+            group_thr: group_thr.max(1),
+            inner: Mutex::new(Inner {
+                role,
+                master,
+                health: HashMap::new(),
+                reports: HashMap::new(),
+                report_addr: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Current status for a peer id (HEALTHY for a never-seen peer).
+    fn status_of(inner: &Inner, id: &str) -> i32 {
+        inner.health.get(id).map(|h| h.status).unwrap_or(mesh::HEALTHY)
+    }
+
+    /// Record a PONG for `id`; folded into the FSM on the next tick.
+    pub fn mark_answered(&self, id: &str) {
+        self.inner.lock().health.entry(id.to_string()).or_default().answered = true;
+    }
+
+    /// Handle an incoming DCF-Mesh control message (REPORT or ROLE).
+    pub fn handle_control(&self, payload: &[u8], from: SocketAddr) {
+        if let Some((nid, peers)) = mesh::unpack_report(payload) {
+            // master side: stash the reporter's view + where to send its ROLE
+            let mut inner = self.inner.lock();
+            inner.reports.insert(nid as u16, peers);
+            inner.report_addr.insert(nid as u16, from);
+            return;
+        }
+        if let Some((nid, role, master)) = mesh::unpack_role(payload) {
+            if nid as u16 != self.node_id {
+                return;
+            }
+            let mut inner = self.inner.lock();
+            let changed = inner.role != role || inner.master != master as u16;
+            inner.role = role;
+            inner.master = master as u16;
+            drop(inner);
+            if changed {
+                log::info!("mesh: role assigned -> {} (master {})", role_name(role), master);
+            }
+        }
+    }
+
+    /// Fold this tick's PONG/timeout into every peer's health window.
+    fn health_tick(&self, peer_ids: &[String]) {
+        let mut inner = self.inner.lock();
+        for id in peer_ids {
+            let h = inner.health.entry(id.clone()).or_default();
+            let ev: u8 = if h.answered { 1 } else { 0 };
+            h.answered = false;
+            h.window.push(ev);
+            if h.window.len() > MESH_WINDOW_CAP {
+                let cut = h.window.len() - MESH_WINDOW_CAP;
+                h.window.drain(0..cut);
+            }
+            h.status = mesh::peer_status(&h.window, MESH_FAIL_THR, MESH_OK_THR);
+        }
+    }
+
+    /// auto mode: REPORT our peer view to the configured master peer.
+    fn send_report(&self, node: &DcfNode, peer_ids: &[String]) {
+        if self.master_peer.is_empty() {
+            return;
+        }
+        let peers: Vec<[i32; 3]> = {
+            let inner = self.inner.lock();
+            peer_ids
+                .iter()
+                .filter_map(|id| {
+                    id.parse::<i32>()
+                        .ok()
+                        .map(|pid| [pid, Self::status_of(&inner, id), node.peer_rtt_ms(id)])
+                })
+                .collect()
+        };
+        let payload = mesh::pack_report(self.node_id as i32, &peers);
+        if let Some((host, port)) = node.get_peer_info(&self.master_peer) {
+            node.send_mesh(payload, &host, port);
+        }
+    }
+
+    /// master mode: aggregate the reported topology, elect, broadcast ROLE.
+    fn run_election(&self, node: &DcfNode) {
+        // 1. Build the node-id set and the deduplicated, canonicalized edge set.
+        let (idset, dedup, addrs) = {
+            let inner = self.inner.lock();
+            let mut idset: std::collections::BTreeSet<u16> = std::collections::BTreeSet::new();
+            idset.insert(self.node_id);
+            let mut dedup: HashMap<(u16, u16), i32> = HashMap::new();
+            for (reporter, peers) in inner.reports.iter() {
+                idset.insert(*reporter);
+                for p in peers {
+                    let peer_id = p[0] as u16;
+                    idset.insert(peer_id);
+                    if p[1] == mesh::UNREACHABLE {
+                        continue; // skip dead links
+                    }
+                    let (a, b) = if *reporter <= peer_id {
+                        (*reporter, peer_id)
+                    } else {
+                        (peer_id, *reporter)
+                    };
+                    let w = p[2];
+                    dedup
+                        .entry((a, b))
+                        .and_modify(|cur| {
+                            if w < *cur {
+                                *cur = w;
+                            }
+                        })
+                        .or_insert(w);
+                }
+            }
+            (idset, dedup, inner.report_addr.clone())
+        };
+
+        // 2. Map node ids to a dense 0..N-1 index (sorted, deterministic).
+        let ids: Vec<u16> = idset.into_iter().collect();
+        let index: HashMap<u16, usize> = ids.iter().enumerate().map(|(i, id)| (*id, i)).collect();
+        let edges: Vec<[i32; 3]> = dedup
+            .iter()
+            .map(|((a, b), w)| [index[a] as i32, index[b] as i32, *w])
+            .collect();
+
+        // 3. Elect.
+        let (master_idx, roles) = mesh::elect(ids.len(), &edges, MESH_RELAY_MIN_DEGREE);
+        let master_id = ids[master_idx as usize];
+
+        // 4. Adopt our own role + master.
+        {
+            let mut inner = self.inner.lock();
+            if let Some(&self_idx) = index.get(&self.node_id) {
+                inner.role = roles[self_idx];
+            }
+            inner.master = master_id;
+        }
+
+        // 5. Unicast each reporter its assigned role.
+        for (reporter, addr) in addrs {
+            if let Some(&idx) = index.get(&reporter) {
+                let payload = mesh::pack_role(reporter as i32, roles[idx], master_id as i32);
+                node.send_mesh_addr(payload, addr);
+            }
+        }
+    }
+
+    /// auto mode: if our master peer is Unreachable, locally re-elect the lowest-id
+    /// healthy node (decentralized failover — no central point of failure).
+    fn check_master_failover(&self, peer_ids: &[String]) {
+        let mut inner = self.inner.lock();
+        if self.master_peer.is_empty()
+            || Self::status_of(&inner, &self.master_peer) != mesh::UNREACHABLE
+        {
+            return;
+        }
+        let mut best = self.node_id as i32;
+        for id in peer_ids {
+            if Self::status_of(&inner, id) == mesh::UNREACHABLE {
+                continue;
+            }
+            if let Ok(pid) = id.parse::<i32>() {
+                if pid < best {
+                    best = pid;
+                }
+            }
+        }
+        let prev = inner.master;
+        let changed = prev != best as u16;
+        inner.master = best as u16;
+        if best == self.node_id as i32 {
+            inner.role = mesh::MASTER;
+        }
+        drop(inner);
+        if changed {
+            log::info!(
+                "mesh: master {} unreachable -> local re-election, new master {}",
+                prev,
+                best
+            );
+        }
+    }
+
+    /// Emit the periodic mesh-status line.
+    fn log_status(&self, node: &DcfNode, peer_ids: &[String]) {
+        let inner = self.inner.lock();
+        let parts: Vec<String> = peer_ids
+            .iter()
+            .map(|id| {
+                let st = Self::status_of(&inner, id);
+                let grp = mesh::group_of(node.peer_rtt_ms(id), self.group_thr, st);
+                format!("{}:{}:g{}", id, status_name(st), grp)
+            })
+            .collect();
+        let (role, master) = (inner.role, inner.master);
+        drop(inner);
+        log::info!(
+            "mesh-status node={} mode={} role={} master={} peers=[{}]",
+            self.node_id,
+            self.mode,
+            role_name(role),
+            master,
+            parts.join(" ")
+        );
+    }
+
+    /// The mesh loop: one tick per second until the node stops.
+    pub async fn run(self: Arc<Self>, node: Arc<DcfNode>) {
+        let mut ticker = tokio::time::interval(Duration::from_secs(1));
+        let mut tick: u64 = 0;
+        loop {
+            ticker.tick().await;
+            if !node.is_running() {
+                return;
+            }
+            let peers = node.list_peers();
+            self.health_tick(&peers);
+            for id in &peers {
+                let _ = node.send_ping(id);
+            }
+            match self.mode.as_str() {
+                "auto" => {
+                    self.send_report(&node, &peers);
+                    self.check_master_failover(&peers);
+                }
+                "master" => self.run_election(&node),
+                _ => {} // p2p: health FSM only
+            }
+            tick += 1;
+            if tick % 3 == 0 {
+                self.log_status(&node, &peers);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fsm_window_unreachable_then_recovers() {
+        let m = MeshRuntime::new("auto", 1, "0", 50);
+        let peers = vec!["2".to_string()];
+        // 3 consecutive timeouts -> Unreachable.
+        for _ in 0..3 {
+            m.health_tick(&peers);
+        }
+        assert_eq!(MeshRuntime::status_of(&m.inner.lock(), "2"), mesh::UNREACHABLE);
+        // 2 consecutive PONGs -> recover to Healthy.
+        for _ in 0..2 {
+            m.mark_answered("2");
+            m.health_tick(&peers);
+        }
+        assert_eq!(MeshRuntime::status_of(&m.inner.lock(), "2"), mesh::HEALTHY);
+    }
+
+    #[test]
+    fn degraded_after_single_timeout() {
+        let m = MeshRuntime::new("auto", 1, "0", 50);
+        let peers = vec!["2".to_string()];
+        m.mark_answered("2");
+        m.health_tick(&peers); // ok
+        m.health_tick(&peers); // one timeout
+        assert_eq!(MeshRuntime::status_of(&m.inner.lock(), "2"), mesh::DEGRADED);
+    }
+
+    #[test]
+    fn role_adoption_via_control() {
+        let m = MeshRuntime::new("auto", 7, "0", 50);
+        let payload = mesh::pack_role(7, mesh::RELAY, 3);
+        m.handle_control(&payload, "127.0.0.1:9000".parse().unwrap());
+        let inner = m.inner.lock();
+        assert_eq!(inner.role, mesh::RELAY);
+        assert_eq!(inner.master, 3);
+    }
+}


### PR DESCRIPTION
Brings the Phase-3 self-healing mesh to the last two wire-codec languages, so a **Rust** or **Python** node joins the same mesh as the Go/C nodes. Both drive the certified algorithms (`codec/src/mesh.rs`, `python/MCP/meshlab_core.py`) from live PING/PONG + the `MsgMesh` REPORT/ROLE control adapter. **Certified primitives and golden vectors are untouched** — all four mesh certs (Python/Rust/C/Go) still pass.

## Rust (direct port of `go/node/mesh_runtime.go`)
- `rust/src/mesh_runtime.rs` — liveness FSM (window 5, fail 3→Unreachable, ok 2→recover), AUTO/master loop (REPORT→aggregate→`elect`→ROLE), decentralized failover, periodic `mesh-status` line.
- `rust/src/lib.rs` — `mesh` field + `enable_mesh`/`mesh()`, `peer_id_by_addr`/`peer_rtt_ms`/`send_mesh` helpers, PONG→`mark_answered` + `MsgMesh`→`handle_control` hooks, `run_mesh_runtime` spawner.
- `rust/src/main.rs` — `dcf mesh --mode/--node-id/--master/--peer` subcommand.
- **Bug fix:** `send_message` used `SocketAddr::parse` (rejects hostnames) and `to_socket_addrs` returned IPv6 `::1` first while nodes bind IPv4 — so the Rust node never reached hostname peers (`localhost`). Now resolves via getaddrinfo, IPv4 preferred (matches Go). This silently broke outbound PING/REPORT.

## Python (new stdlib-only UDP node — *not* the gRPC `dcf.client`)
- `dcf/proto.py` (binary ProtoMessage, byte-identical to Go/Rust), `dcf/udp_node.py` (socket+threading, PING/PONG, RTT EMA, MsgMesh dispatch), `dcf/mesh_runtime.py` (runtime over `meshlab_core`), `dcf_node.py` (`start`/`wiretap` CLI). `__init__` made grpc-optional.

## Data-leak demo (the wire is plaintext by design for EAR/ITAR)
- `dcf/wiretap.py` + `examples/wiretap_demo.py`: a passive on-path relay decoding REPORT topology, ROLE assignments, and message contents with zero credentials.
- `tests/test_eavesdrop_leak.py`: proves the leak from two live nodes through a tap, then that an **external** transport wrapper (WireGuard stand-in, never in the codec) defeats it.
- `Documentation/DCF_SECURITY_EXPOSURE.md` + CLAUDE.md note: deploy behind WireGuard / operator crypto **beneath** the UDP socket; keep the core wire encryption-free.

## Docs
- New `Documentation/DCF_MESH_SPEC.md` (adapter + runtime spec, parallel to the other adapter specs) and a DCF-Mesh section in `CLAUDE.md`.
- Also: fixed a pre-existing `NameError` (missing `typing.List`) in `dcf/mcp_client.py`; added `python/pytest.ini` so pytest's rootdir stops at the SDK.

## Verification
`cargo test` (Rust lib + codec), `pytest` (FSM + envelope + eavesdrop leak/mitigation), all four mesh certs, and a **live 3-node mixed-language mesh** (Go master + Rust auto + Python auto): roles propagate cross-language; killing the master triggers decentralized re-election on both survivors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018ftmNsJGD72BM4LhwrZrNU