### PR TITLE
ffmpeg-dcf: native `dcf` demuxer + `dcf-rec` CLI (record DCF-Audio to any format)

### DIFF
--- a/ffmpeg-dcf/README.md
+++ b/ffmpeg-dcf/README.md
@@ -1,0 +1,97 @@
+# DCF-Audio → FFmpeg (`dcf` demuxer + `dcf-rec`)
+
+A **native FFmpeg demuxer** for the DeMoD DCF-Audio wire, so stock FFmpeg can
+record audio carried over `DeModFrame`s into any container/codec it supports:
+
+```sh
+nix build .#dcf-ffmpeg                              # patched ffmpeg (builds the demuxer in)
+ffmpeg -f dcf -i capture.dcf out.flac              # transcode to anything
+ffmpeg -f dcf -i capture.dcf -map 0:a:0 peerA.wav  # pull one peer's track
+dcf-rec capture.dcf -o master.mka                  # CLI front door, format by extension
+```
+
+## `dcf-rec` — the CLI front door
+
+One ergonomic command (Python; reuses the certified `python/MCP` + `python/dcf`
+modules) over the `dcf` demuxer. Bare `dcf-rec INPUT ...` is shorthand for
+`dcf-rec rec INPUT ...`.
+
+```sh
+# record (type by extension; multi-peer -> downmix, except .mka = multitrack master)
+dcf-rec capture.dcf -o out.flac
+dcf-rec capture.dcf                       # no -o  -> capture.flac (mixdown)
+dcf-rec capture.dcf -o master.mka         # one bit-exact track per peer
+cat capture.dcf | dcf-rec - -o out.wav    # stdin;  -o - + --format = stdout
+
+# inspect: peers, codecs, duration, packet loss, channels
+dcf-rec info capture.dcf                   # table   (--json for scripts)
+
+# per-peer stems (DAW): one file per peer, named by src id
+dcf-rec split capture.dcf --out-dir stems/ --format wav
+#   stems/peer-0x00a1.wav, stems/peer-0x0042.wav, ...
+
+# record live off the wire (passive sniffer; Ctrl-C to stop)
+dcf-rec listen --bind :7100 -o jam.flac
+dcf-rec listen --bind :7100 --forward host:7000 -o jam.flac   # transparent inline tap
+```
+
+Each peer (frame `src`) becomes one stream, tagged `title="peer 0x<id>"` so
+players, `ffprobe`, and `.mka` tracks name it. `info` durations/loss come from a
+direct frame scan (accurate), not ffprobe's bitrate estimate.
+
+This is **not a new wire format**. DCF-Audio is an *adapter* over the certified
+17-byte wire quantum; the demuxer reuses the certified C reassembler + frame codec
+(`codec/demod_audio.h`, `codec/demod_frame.h`) verbatim, so the bytes it hands
+FFmpeg are provably the same ones `Documentation/audio_vectors.json` and the
+246-vector wire certificate pin. See `Documentation/DCF_AUDIO_SPEC.md`.
+
+## The `.dcf` frame-dump format
+
+A flat concatenation of **17-byte `DeModFrame`s** — exactly the AUDIO adapter
+frames that ride on the wire (one `DeModFrame` per UDP `MSG_AUDIO` payload). It is
+self-synchronising: every record starts with sync `0xD3` and ends with a
+CRC-16/CCITT-FALSE over bytes `[0..14]`, so the demuxer can probe and resync.
+
+Produce one with either:
+
+```sh
+# deterministic PCM-diag test tone (+ per-source ground-truth .u8 sidecars)
+python3 python/MCP/gen_audio_dump.py capture.dcf --src 1 --src 7 --blocks 50
+
+# or capture live AUDIO frames off the plaintext wire
+python3 python/dcf_node.py wiretap --bind 0.0.0.0:7100 --forward host:7000 --dump capture.dcf
+```
+
+## Codec-id → FFmpeg mapping
+
+Each frame `src` id becomes one audio stream. The descriptor's `codec_id` maps
+onto existing FFmpeg decoders, so **no custom `AVCodec` is needed** — only the
+demuxer:
+
+| `codec_id` | DCF codec | FFmpeg stream | Notes |
+|---|---|---|---|
+| 0 | Opus, 48 kHz mono | `AV_CODEC_ID_OPUS` (+ `OpusHead`) | `-c:a copy` is bit-exact |
+| 1 | PCM-diag, u8 @ 6 kHz | `AV_CODEC_ID_PCM_U8` | the bytes *are* unsigned-8 PCM |
+| 2 | Faust phase-mod | `AV_CODEC_ID_PCM_F32LE` @ 48 kHz | **synthesised inside the demuxer** via `dcf_pm_synth_block_ffi` |
+
+Packet PTS = the source's unwrapped 11-bit `packet_id` × the 20 ms block length
+(in `1/sample_rate` units), so dropped blocks surface as honest PTS gaps.
+
+## Files
+
+- `dcfdec.c` — the demuxer (`ff_dcf_demuxer`, name `"dcf"`). Dropped into
+  `libavformat/` at build time alongside the certified headers and the PM synth
+  object (`codec/faust/dcf_pm_codec.gen.c`).
+- `dcf-rec` — thin CLI wrapper; selects ffmpeg args by output extension.
+- Build/registration lives in `flake.nix` (`packages.dcf-ffmpeg`): it copies the
+  sources into the FFmpeg tree, inserts `extern const FFInputFormat
+  ff_dcf_demuxer;` into `libavformat/allformats.c` (which `configure`'s
+  `find_things_extern` scans), and appends the `OBJS-$(CONFIG_DCF_DEMUXER)` line.
+
+## Version pin
+
+Written against the FFmpeg the flake's `nixpkgs` provides (**8.x / libavformat
+62**, the `FFInputFormat` demuxer API). FFmpeg's internal demuxer API is not
+stable across majors; if the pin moves to a new FFmpeg major, re-check the
+`FFInputFormat` struct and `ff_alloc_extradata` / `avpriv_set_pts_info` in
+`libavformat/{demux.h,internal.h}`.

--- a/ffmpeg-dcf/dcf-rec
+++ b/ffmpeg-dcf/dcf-rec
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-only
+# Copyright (c) 2026 DeMoD LLC.
+"""dcf-rec — capture, inspect, and record DCF-Audio over the `dcf` ffmpeg demuxer.
+
+DCF-Audio is an adapter over the 17-byte DeModFrame wire quantum. A ".dcf" dump is
+a flat concatenation of those frames (one per UDP MSG_AUDIO payload). This tool is
+the front door to the native `dcf` demuxer built into `dcf-ffmpeg`:
+
+  dcf-rec INPUT.dcf -o OUT.ext     record to a file (type by extension)
+  dcf-rec info INPUT.dcf           inspect: peers, codecs, duration, packet loss
+  dcf-rec split INPUT.dcf          one file per peer (DAW stems)
+  dcf-rec listen --bind :7100 ...  capture audio live off the wire
+
+ffmpeg/ffprobe come from $PATH (the Nix `dcf-rec` package injects `dcf-ffmpeg`);
+override with FFMPEG=/path FFPROBE=/path for a local patched build.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+# Resolve repo root from this script's location so the certified Python modules
+# import whether run from a checkout or the read-only Nix store.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+sys.path.insert(0, os.path.join(_ROOT, "python", "MCP"))
+sys.path.insert(0, os.path.join(_ROOT, "python"))
+
+import audiolab_core as al               # certified L2 framing + codec ids
+from wirelab_core import decode          # certified DeModFrame decode
+
+FFMPEG = os.environ.get("FFMPEG", "ffmpeg")
+FFPROBE = os.environ.get("FFPROBE", "ffprobe")
+FRAME_SIZE = 17
+BLOCK_S = 0.020                          # 20 ms per audio block
+PROG = "dcf-rec"
+
+# codec_id -> (ffmpeg codec_name as the demuxer presents it, sample rate)
+CODEC_INFO = {
+    al.CODEC_OPUS:     ("opus", 48000),
+    al.CODEC_PCM_DIAG: ("pcm_u8", al.PCM_DIAG_RATE),
+    al.CODEC_FAUST_PM: ("pm/pcm_f32le", 48000),
+}
+SUBCMDS = ("rec", "info", "split", "listen")
+
+
+def err(msg, code=2):
+    print(f"{PROG}: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def run(cmd):
+    r = subprocess.run(cmd)
+    if r.returncode != 0:
+        err(f"ffmpeg failed ({r.returncode})", code=1)
+
+
+def split_hostport(s):
+    host, _, port = s.rpartition(":")
+    if not port:
+        err(f"expected host:port, got {s!r}")
+    return (host or "0.0.0.0", int(port))
+
+
+# ── codec selection by output extension (shared by rec + split) ───────────────
+def ext_codec(ext, is_opus):
+    """ffmpeg `-c:a ...` args for a single audio stream of extension `ext`."""
+    if ext == "wav":
+        return ["-c:a", "pcm_s16le"]
+    if ext == "flac":
+        return ["-c:a", "flac"]
+    if ext == "mp3":
+        return ["-c:a", "libmp3lame", "-q:a", "2"]
+    if ext in ("m4a", "aac"):
+        return ["-c:a", "aac"]
+    if ext in ("opus", "ogg"):
+        return ["-c:a", "copy"] if is_opus else ["-c:a", "libopus"]
+    err(f"unsupported output type .{ext}")
+
+
+# raw-muxer name for stdout (where ffmpeg can't infer from a filename)
+EXT_MUXER = {"wav": "wav", "flac": "flac", "mp3": "mp3", "m4a": "ipod",
+             "aac": "adts", "opus": "opus", "ogg": "ogg", "mka": "matroska"}
+
+
+def probe_streams(input_spec):
+    out = subprocess.run(
+        [FFPROBE, "-v", "error", "-f", "dcf", "-i", input_spec, "-select_streams", "a",
+         "-show_entries", "stream=index,id,codec_name:stream_tags=title", "-of", "json"],
+        capture_output=True, text=True)
+    try:
+        return json.loads(out.stdout or "{}").get("streams", [])
+    except json.JSONDecodeError:
+        return []
+
+
+def stream_src(s):
+    """The peer (frame src) id for a stream. Prefer the demuxer's "peer 0xNNNN"
+    title tag (always set); fall back to AVStream.id (only shown with SHOW_IDS)."""
+    title = (s.get("tags") or {}).get("title", "")
+    if title.startswith("peer 0x"):
+        try:
+            return int(title[len("peer 0x"):], 16)
+        except ValueError:
+            pass
+    v = s.get("id", 0)
+    try:
+        return int(v, 0) if isinstance(v, str) else int(v)
+    except (ValueError, TypeError):
+        return 0
+
+
+# ── frame scan (pure-python: accurate pkts/loss/duration the demuxer omits) ───
+def scan(path):
+    with open(path, "rb") as f:
+        data = f.read()
+    per = {}            # src -> stats
+    reasm = {}          # src -> AudioReassembler
+    for i in range(0, len(data) - FRAME_SIZE + 1, FRAME_SIZE):
+        frame = data[i:i + FRAME_SIZE]
+        try:
+            d = decode(frame)
+        except ValueError:
+            continue
+        if d["frame_type"] != al.FCTRL:
+            continue
+        src, dst = d["src"], d["dst"]
+        st = per.setdefault(src, {"codec": None, "pids": set(), "chans": set()})
+        st["chans"].add(dst)
+        r = reasm.setdefault(src, al.AudioReassembler())
+        for ev in r.push(frame):
+            if ev[0] == "packet":
+                _, pid, _ts, cid, _payload, _flags = ev
+                st["pids"].add(pid)
+                st["codec"] = cid
+    out = {}
+    for src, st in per.items():
+        pids = st["pids"]
+        received = len(pids)
+        expected = (max(pids) - min(pids) + 1) if pids else 0   # within one pid wrap
+        dropped = max(0, expected - received)
+        cid = st["codec"]
+        cname, rate = CODEC_INFO.get(cid, (f"codec{cid}", 0))
+        out[src] = {
+            "src": src, "codec_id": cid, "codec": cname, "sample_rate": rate,
+            "packets": received, "dropped": dropped,
+            "loss_pct": round(100.0 * dropped / expected, 2) if expected else 0.0,
+            "duration_s": round(expected * BLOCK_S, 2),
+            "channels": sorted(st["chans"]),
+        }
+    return out
+
+
+def print_info(per, as_json=False):
+    if as_json:
+        print(json.dumps(list(per.values()), indent=2))
+        return
+    if not per:
+        print("(no DCF-Audio streams found)", file=sys.stderr)
+        return
+    print(f"{'src':<10}{'codec':<15}{'rate':>7}  {'dur':>7}  {'pkts':>6}  "
+          f"{'loss':>6}  channels")
+    for src in sorted(per):
+        r = per[src]
+        chans = ",".join(f"CH{c}" for c in r["channels"])
+        print(f"0x{src:04x}    {r['codec']:<15}{r['sample_rate']:>7}  "
+              f"{r['duration_s']:>6.2f}s  {r['packets']:>6}  "
+              f"{r['loss_pct']:>5.1f}%  {chans}")
+
+
+# ── subcommands ───────────────────────────────────────────────────────────────
+def transcode(input_spec, out, ext, yes, allow_multi=True):
+    """Run ffmpeg: .dcf -> a single output file/stream of type `ext`."""
+    is_stdin = input_spec == "pipe:0"
+    streams = [] if is_stdin else probe_streams(input_spec)
+    n = len(streams) if streams else 1
+    all_opus = bool(streams) and all(s.get("codec_name") == "opus" for s in streams)
+
+    cmd = [FFMPEG, "-hide_banner", "-loglevel", "error"]
+    if yes or out == "pipe:1":
+        cmd += ["-y"]
+    cmd += ["-f", "dcf", "-i", input_spec]
+
+    if ext == "mka":                                  # multitrack master, one per peer
+        for i in range(n):
+            cmd += ["-map", f"0:a:{i}"]
+        cmd += ["-c:a", "copy"]
+    else:
+        if n > 1 and allow_multi:                     # downmix multiple peers
+            cmd += ["-filter_complex",
+                    f"amix=inputs={n}:duration=longest:normalize=0[a]", "-map", "[a]"]
+        cmd += ext_codec(ext, all_opus)
+    if out == "pipe:1":
+        cmd += ["-f", EXT_MUXER.get(ext, ext)]
+    cmd += [out]
+    run(cmd)
+
+
+def cmd_rec(args):
+    inp = "pipe:0" if args.input == "-" else args.input
+    out = args.output or args.out_pos
+    if out is None:
+        if args.input == "-":
+            err("recording from stdin requires -o OUTPUT (or --format with -o -)")
+        out = os.path.splitext(args.input)[0] + "." + (args.format or "flac")
+    if out == "-":
+        if not args.format:
+            err("writing to stdout (-o -) requires --format EXT")
+        ext, out_spec = args.format, "pipe:1"
+    else:
+        ext = args.format or out.rsplit(".", 1)[-1].lower()
+        out_spec = out
+    transcode(inp, out_spec, ext, args.yes)
+    if out_spec != "pipe:1":
+        print(f"{PROG}: wrote {out}", file=sys.stderr)
+
+
+def cmd_info(args):
+    print_info(scan(args.input), as_json=args.json)
+
+
+def cmd_split(args):
+    streams = probe_streams(args.input)
+    if not streams:
+        err("no audio streams in input", code=1)
+    os.makedirs(args.out_dir, exist_ok=True)
+    ext = args.format
+    written = []
+    for pos, s in enumerate(streams):
+        sid = stream_src(s)
+        out = os.path.join(args.out_dir, f"peer-0x{sid:04x}.{ext}")
+        is_opus = s.get("codec_name") == "opus"
+        cmd = [FFMPEG, "-hide_banner", "-loglevel", "error", "-y", "-f", "dcf",
+               "-i", args.input, "-map", f"0:a:{pos}", *ext_codec(ext, is_opus), out]
+        run(cmd)
+        written.append(out)
+    print(f"{PROG}: wrote {len(written)} per-peer track(s) to {args.out_dir}/",
+          file=sys.stderr)
+    for w in written:
+        print(f"  {w}", file=sys.stderr)
+
+
+def cmd_listen(args):
+    import signal
+    import threading
+    from dcf.wiretap import Wiretap
+    from dcf.proto import ProtoMessage, MSG_AUDIO
+
+    bind = split_hostport(args.bind)
+    forward = split_hostport(args.forward) if args.forward else None
+    keep = args.keep or tempfile.mktemp(prefix="dcf-rec-", suffix=".dcf")
+    dump = open(keep, "wb")
+    n = [0]
+
+    def on_capture(data, _src, _summary):
+        try:
+            msg = ProtoMessage.deserialize(data)
+        except ValueError:
+            return
+        if msg.msg_type == MSG_AUDIO and len(msg.payload) == FRAME_SIZE:
+            dump.write(msg.payload)
+            n[0] += 1
+
+    # Explicit handlers (Ctrl-C *and* `kill`) driving an Event — reliable shutdown
+    # even with the capture daemon thread running.
+    stop = threading.Event()
+    signal.signal(signal.SIGINT, lambda *_: stop.set())
+    signal.signal(signal.SIGTERM, lambda *_: stop.set())
+
+    tap = Wiretap(bind, forward, on_capture=on_capture, label="dcf-rec")
+    relay = f" (relaying to {args.forward})" if forward else ""
+    print(f"{PROG} listen: capturing AUDIO on {args.bind}{relay} — Ctrl-C to stop",
+          file=sys.stderr)
+    tap.start()
+    try:
+        while not stop.wait(0.5):
+            pass
+    finally:
+        tap.stop()
+        dump.close()
+    print(f"\n{PROG}: captured {n[0]} audio frame(s) -> {keep}", file=sys.stderr)
+    if n[0]:
+        print_info(scan(keep))
+    if args.output:
+        ext = args.format or args.output.rsplit(".", 1)[-1].lower()
+        transcode(keep, args.output, ext, True)
+        print(f"{PROG}: wrote {args.output}", file=sys.stderr)
+    elif not args.keep:
+        print(f"{PROG}: capture kept at {keep} (use -o to record, --keep to name it)",
+              file=sys.stderr)
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog=PROG, description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="command", required=True)
+
+    r = sub.add_parser("rec", help="record a .dcf into an audio file (type by extension)")
+    r.add_argument("input", help=".dcf frame dump, or - for stdin")
+    r.add_argument("out_pos", nargs="?", metavar="OUTPUT", help="output file")
+    r.add_argument("-o", "--output", help="output file (or - for stdout)")
+    r.add_argument("--format", help="output type override (wav/flac/opus/ogg/mka/mp3/m4a)")
+    r.add_argument("-y", "--yes", action="store_true", help="overwrite output")
+    r.set_defaults(func=cmd_rec)
+
+    i = sub.add_parser("info", help="show peers, codecs, duration, packet loss")
+    i.add_argument("input", help=".dcf frame dump")
+    i.add_argument("--json", action="store_true", help="machine-readable output")
+    i.set_defaults(func=cmd_info)
+
+    s = sub.add_parser("split", help="write one file per peer (DAW stems)")
+    s.add_argument("input", help=".dcf frame dump")
+    s.add_argument("--out-dir", default=".", help="directory for per-peer files")
+    s.add_argument("--format", default="wav", help="per-peer file type (default wav)")
+    s.set_defaults(func=cmd_split)
+
+    l = sub.add_parser("listen", help="capture audio live off the wire")
+    l.add_argument("--bind", required=True, metavar="HOST:PORT", help="listen address")
+    l.add_argument("-o", "--output", help="record to this file on stop")
+    l.add_argument("--format", help="output type override")
+    l.add_argument("--forward", metavar="HOST:PORT",
+                   help="also relay datagrams here (transparent inline tap)")
+    l.add_argument("--keep", metavar="FILE.dcf", help="keep the raw capture at this path")
+    l.add_argument("-y", "--yes", action="store_true", help="overwrite output")
+    l.set_defaults(func=cmd_listen)
+    return p
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # Ergonomic default: a bare `dcf-rec INPUT ...` means `dcf-rec rec INPUT ...`.
+    if argv and argv[0] not in SUBCMDS and argv[0] not in ("-h", "--help"):
+        argv = ["rec"] + argv
+    args = build_parser().parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ffmpeg-dcf/dcf_pm_ff.c
+++ b/ffmpeg-dcf/dcf_pm_ff.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright (c) 2026 DeMoD LLC.
+//
+// FFmpeg build shim for the DCF Faust phase-mod synth (codec_id 2). It compiles
+// the committed, verbatim Faust output (dcf_pm_codec.gen.c, which #includes
+// dcf_pm_faust.c) into libavformat and exposes dcf_pm_synth_block_ffi for the
+// `dcf` demuxer. The Faust-generated C deliberately uses global functions with no
+// separate prototypes; FFmpeg builds with -Werror=missing-prototypes, so we
+// locally relax just that one diagnostic for this third-party-style codegen — the
+// synthesis bytes themselves are unchanged (and intentionally NOT byte-certified).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#include "dcf_pm_codec.gen.c"
+#pragma GCC diagnostic pop

--- a/ffmpeg-dcf/dcfdec.c
+++ b/ffmpeg-dcf/dcfdec.c
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+/*
+ * libavformat/dcfdec.c — DeMoD DCF-Audio frame-dump demuxer ("dcf")
+ * DeMoD LLC | LGPL-3.0
+ *
+ * Reads a ".dcf" frame dump — a flat concatenation of 17-byte DeModFrames, the
+ * AUDIO adapter frames that ride on the DCF wire (one DeModFrame per UDP
+ * MSG_AUDIO payload; see python/MCP/gen_audio_dump.py and `dcf_node wiretap
+ * --dump`). DCF-Audio is an *adapter* over the 17-byte wire quantum: a 20 ms
+ * codec block is serialised into 1 + frag_total CTRL frames. This demuxer reuses
+ * the *certified* L2 reassembler and frame codec verbatim (demod_audio.h /
+ * demod_frame.h, pinned by Documentation/audio_vectors.json + golden_vectors.json),
+ * so what it hands FFmpeg is provably the same bytes the certificate covers.
+ *
+ * Each frame `src` id becomes one audio AVStream (audio is per-source, keyed by
+ * src — mirrors the comms client's per-source tracks). The DCF codec id in the
+ * packet descriptor maps onto existing FFmpeg decoders, so no custom AVCodec is
+ * needed:
+ *
+ *   codec_id 0  Opus      -> AV_CODEC_ID_OPUS  (+ OpusHead extradata; -c:a copy is bit-exact)
+ *   codec_id 1  PCM-diag  -> AV_CODEC_ID_PCM_U8 @ 6 kHz (the bytes *are* unsigned-8 PCM)
+ *   codec_id 2  Faust-PM  -> synthesised here to AV_CODEC_ID_PCM_F32LE @ 48 kHz
+ *
+ * Packet PTS is the source's unwrapped 11-bit packet_id times the 20 ms block
+ * length (in 1/sample_rate units), so lost blocks surface as honest PTS gaps.
+ */
+#include "libavutil/channel_layout.h"
+#include "libavutil/dict.h"
+#include "libavutil/intreadwrite.h"
+#include "avformat.h"
+#include "demux.h"
+#include "internal.h"
+
+/* Certified DCF codec: L2 reassembler + 17-byte frame codec + constants.
+ * Included without DCF_AUDIO_{OPUS,PM,RT} so it pulls no libopus / synth deps. */
+#include "demod_audio.h"
+
+/* PM synthesis (codec_id 2): provided by dcf_pm_codec.gen.o, linked alongside. */
+extern void dcf_pm_synth_block_ffi(const uint8_t *params8, float *out, int n);
+
+#define DCF_MAX_SRCS         64
+#define DCF_PID_MOD          2048ULL    /* 11-bit packet_id space                 */
+#define DCF_PM_BLOCK_SAMPLES 960        /* 20 ms @ 48 kHz PM synthesis block      */
+
+/* Keep the certified codec registry ODR-referenced so its (non-inline) static
+ * vtable + helpers are not flagged unused when we don't call the registry. */
+__attribute__((unused))
+static const void *const dcf__keep = (const void *)dcf_codec_get;
+
+typedef struct DCFStream {
+    int      used;
+    uint16_t src_id;
+    int      stream_index;          /* -1 until the first complete packet         */
+    uint8_t  codec_id;
+    int      block_samples;         /* PTS units per 20 ms packet                 */
+    int      have_pid;
+    uint64_t pid_abs;               /* last unwrapped absolute packet_id          */
+    dcf_audio_reasm_t reasm;        /* per-source: reassembler keys by packet_id  */
+} DCFStream;
+
+typedef struct DCFDemuxContext {
+    DCFStream srcs[DCF_MAX_SRCS];
+} DCFDemuxContext;
+
+/* Unwrap an 11-bit rolling packet_id to a monotonic absolute index relative to a
+ * previous absolute value (forward progress dominates; small backward = reorder).
+ * Mirrors client/src-tauri/src/sync.rs::unwrap_pid. */
+static uint64_t dcf_unwrap_pid(uint64_t prev_abs, uint16_t raw)
+{
+    uint64_t prev_lo = prev_abs % DCF_PID_MOD;
+    uint64_t r       = (uint64_t)raw % DCF_PID_MOD;
+    uint64_t fwd     = (r + DCF_PID_MOD - prev_lo) % DCF_PID_MOD;
+    if (fwd <= DCF_PID_MOD / 2)
+        return prev_abs + fwd;
+    uint64_t back = DCF_PID_MOD - fwd;
+    return prev_abs >= back ? prev_abs - back : 0;
+}
+
+static int dcf_probe(const AVProbeData *p)
+{
+    int n = 0;
+    for (int i = 0; i + (int)DCF_FRAME_SIZE <= p->buf_size && n < 8;
+         i += DCF_FRAME_SIZE) {
+        if (!dcf_frame_valid(p->buf + i))   /* sync byte 0xD3 + CRC-16/CCITT gate */
+            return 0;
+        n++;
+    }
+    if (n == 0)
+        return 0;
+    /* A CRC-validated run of frames is essentially impossible by chance. */
+    return n >= 2 ? AVPROBE_SCORE_MAX : AVPROBE_SCORE_EXTENSION + 1;
+}
+
+static int dcf_read_header(AVFormatContext *s)
+{
+    /* Streams appear lazily as new `src` ids are seen. */
+    s->ctx_flags |= AVFMTCTX_NOHEADER;
+    return 0;
+}
+
+static DCFStream *dcf_src(DCFDemuxContext *c, uint16_t src_id)
+{
+    DCFStream *slot = NULL;
+    for (int i = 0; i < DCF_MAX_SRCS; i++) {
+        if (c->srcs[i].used && c->srcs[i].src_id == src_id)
+            return &c->srcs[i];
+        if (!c->srcs[i].used && !slot)
+            slot = &c->srcs[i];
+    }
+    if (slot) {
+        slot->used         = 1;
+        slot->src_id       = src_id;
+        slot->stream_index = -1;
+    }
+    return slot;
+}
+
+static int dcf_open_stream(AVFormatContext *s, DCFStream *ds,
+                           const dcf_audio_packet_t *ap)
+{
+    AVStream *st = avformat_new_stream(s, NULL);
+    if (!st)
+        return AVERROR(ENOMEM);
+    AVCodecParameters *par = st->codecpar;
+
+    par->codec_type = AVMEDIA_TYPE_AUDIO;
+    av_channel_layout_default(&par->ch_layout, 1);   /* mono */
+    ds->codec_id = ap->codec_id;
+
+    switch (ap->codec_id) {
+    case DCF_CODEC_OPUS:
+        par->codec_id     = AV_CODEC_ID_OPUS;
+        par->sample_rate  = 48000;
+        ds->block_samples = 960;
+        /* OpusHead (RFC 7845 §5.1): mono, 48 kHz, 3840-sample preskip — lets a
+         * downstream muxer carry the raw Opus packets bit-exact with -c:a copy. */
+        {
+            int ret = ff_alloc_extradata(par, 19);
+            if (ret < 0)
+                return ret;
+            uint8_t *e = par->extradata;
+            memcpy(e, "OpusHead", 8);
+            e[8] = 1;                 /* version       */
+            e[9] = 1;                 /* channel count */
+            AV_WL16(e + 10, 3840);    /* pre-skip      */
+            AV_WL32(e + 12, 48000);   /* input rate    */
+            AV_WL16(e + 16, 0);       /* output gain   */
+            e[18] = 0;                /* mapping family 0 */
+        }
+        break;
+    case DCF_CODEC_PCM_DIAG:
+        par->codec_id              = AV_CODEC_ID_PCM_U8;
+        par->sample_rate           = DCF_PCM_DIAG_RATE;    /* 6000 */
+        par->bits_per_coded_sample = 8;
+        ds->block_samples          = DCF_PCM_DIAG_BLOCK;   /* 120  */
+        break;
+    case DCF_CODEC_FAUST_PM:
+        par->codec_id              = AV_CODEC_ID_PCM_F32LE;
+        par->sample_rate           = 48000;
+        par->bits_per_coded_sample = 32;
+        ds->block_samples          = DCF_PM_BLOCK_SAMPLES; /* 960 */
+        break;
+    default:
+        av_log(s, AV_LOG_WARNING,
+               "dcf: unknown codec_id %u for src 0x%04x — emitting raw bytes\n",
+               ap->codec_id, ds->src_id);
+        par->codec_id     = AV_CODEC_ID_NONE;
+        par->sample_rate  = 48000;
+        ds->block_samples = 960;
+        break;
+    }
+
+    st->id         = ds->src_id;   /* the peer (frame src) id — used for per-peer split */
+    st->start_time = 0;
+    /* Human-readable label so players / ffprobe / mka tracks name each peer. */
+    {
+        char title[32];
+        snprintf(title, sizeof title, "peer 0x%04x", ds->src_id);
+        av_dict_set(&st->metadata, "title", title, 0);
+    }
+    avpriv_set_pts_info(st, 64, 1, par->sample_rate);
+    ds->stream_index = st->index;
+    return 0;
+}
+
+static int dcf_read_packet(AVFormatContext *s, AVPacket *pkt)
+{
+    DCFDemuxContext *c = s->priv_data;
+    AVIOContext *pb = s->pb;
+    uint8_t frame[DCF_FRAME_SIZE];
+
+    for (;;) {
+        if (avio_feof(pb))
+            return AVERROR_EOF;
+
+        int r = avio_read(pb, frame, DCF_FRAME_SIZE);
+        if (r < (int)DCF_FRAME_SIZE)
+            return AVERROR_EOF;           /* clean EOF or trailing partial frame  */
+
+        dcf_frame_t fr;
+        if (!dcf_frame_decode(frame, &fr))
+            continue;                     /* junk between frames — resync          */
+        if (fr.type != DCF_TYPE_CTRL)
+            continue;                     /* not an audio adapter frame            */
+
+        DCFStream *ds = dcf_src(c, fr.src_id);
+        if (!ds)
+            continue;                     /* > DCF_MAX_SRCS distinct sources        */
+
+        dcf_audio_packet_t ap;
+        if (dcf_audio_reasm_push(&ds->reasm, frame, &ap) != DCF_REASM_PACKET)
+            continue;                     /* descriptor/fragments not all in yet    */
+
+        if (ds->stream_index < 0) {
+            int ret = dcf_open_stream(s, ds, &ap);
+            if (ret < 0)
+                return ret;
+        }
+
+        uint64_t abs;
+        if (!ds->have_pid) {
+            abs          = ap.packet_id % DCF_PID_MOD;
+            ds->have_pid = 1;
+            ds->pid_abs  = abs;
+        } else {
+            abs = dcf_unwrap_pid(ds->pid_abs, ap.packet_id);
+            if (abs > ds->pid_abs)
+                ds->pid_abs = abs;
+        }
+        int64_t pts = (int64_t)abs * ds->block_samples;
+
+        int ret;
+        if (ds->codec_id == DCF_CODEC_FAUST_PM) {
+            /* Synthesise the 8-byte PM param block into one f32 PCM block. */
+            ret = av_new_packet(pkt, DCF_PM_BLOCK_SAMPLES * (int)sizeof(float));
+            if (ret < 0)
+                return ret;
+            uint8_t params[8] = { 0 };
+            memcpy(params, ap.payload, ap.payload_len < 8 ? ap.payload_len : 8);
+            dcf_pm_synth_block_ffi(params, (float *)pkt->data, DCF_PM_BLOCK_SAMPLES);
+        } else {
+            /* Opus packet / PCM-diag bytes pass through verbatim. */
+            ret = av_new_packet(pkt, ap.payload_len);
+            if (ret < 0)
+                return ret;
+            memcpy(pkt->data, ap.payload, ap.payload_len);
+        }
+
+        pkt->stream_index = ds->stream_index;
+        pkt->pts          = pts;
+        pkt->dts          = pts;
+        pkt->duration     = ds->block_samples;
+        pkt->flags       |= AV_PKT_FLAG_KEY;
+        return 0;
+    }
+}
+
+const FFInputFormat ff_dcf_demuxer = {
+    .p.name         = "dcf",
+    .p.long_name    = NULL_IF_CONFIG_SMALL("DeMoD DCF-Audio frame dump"),
+    .p.extensions   = "dcf",
+    .p.flags        = AVFMT_GENERIC_INDEX,
+    .priv_data_size = sizeof(DCFDemuxContext),
+    .read_probe     = dcf_probe,
+    .read_header    = dcf_read_header,
+    .read_packet    = dcf_read_packet,
+};

--- a/flake.nix
+++ b/flake.nix
@@ -126,6 +126,46 @@
             meta.mainProgram = "dcf";
           };
 
+          # FFmpeg with the native DCF-Audio demuxer built in. DCF-Audio is an
+          # adapter over the 17-byte wire quantum; ff_dcf_demuxer reuses the
+          # certified C reassembler (codec/demod_audio.h) so `ffmpeg -f dcf -i
+          # capture.dcf out.flac` records audio off the wire into any file type.
+          # See ffmpeg-dcf/README.md. The PM synth (codec_id 2) is compiled in
+          # from codec/faust/dcf_pm_codec.gen.c; codec_id 0/1 ride built-in
+          # opus / pcm_u8 decoders, so only a demuxer is registered.
+          dcf-ffmpeg = pkgs.ffmpeg.overrideAttrs (old: {
+            pname = "dcf-ffmpeg";
+            postPatch = (old.postPatch or "") + ''
+              cp ${self}/ffmpeg-dcf/dcfdec.c            libavformat/dcfdec.c
+              cp ${self}/ffmpeg-dcf/dcf_pm_ff.c         libavformat/dcf_pm_ff.c
+              cp ${self}/codec/demod_frame.h            libavformat/demod_frame.h
+              cp ${self}/codec/demod_audio.h            libavformat/demod_audio.h
+              cp ${self}/codec/faust/dcf_pm_codec.gen.c libavformat/dcf_pm_codec.gen.c
+              cp ${self}/codec/faust/dcf_pm_faust.c     libavformat/dcf_pm_faust.c
+              # Register the demuxer (configure's find_things_extern scans this file).
+              sed -i '/extern const FFInputFormat  *ff_aa_demuxer;/a extern const FFInputFormat  ff_dcf_demuxer;' \
+                  libavformat/allformats.c
+              # Link the demuxer + PM synth (compiled via the missing-prototypes
+              # build shim) when CONFIG_DCF_DEMUXER is on.
+              printf '\nOBJS-$(CONFIG_DCF_DEMUXER) += dcfdec.o dcf_pm_ff.o\n' \
+                  >> libavformat/Makefile
+            '';
+            configureFlags = (old.configureFlags or [ ]) ++ [ "--enable-demuxer=dcf" ];
+            doCheck = false;
+            meta = (old.meta or { }) // {
+              description = "FFmpeg with the native DCF-Audio (dcf) demuxer";
+            };
+          });
+
+          # CLI front door to the `dcf` demuxer: record / inspect / split / listen.
+          # Python (reuses the certified python/MCP + python/dcf modules) and shells
+          # ffmpeg/ffprobe from dcf-ffmpeg. See ffmpeg-dcf/dcf-rec + README.
+          dcf-rec = pkgs.writeShellApplication {
+            name = "dcf-rec";
+            runtimeInputs = [ dcf-ffmpeg pkgs.python3 ];
+            text = ''exec python3 ${self}/ffmpeg-dcf/dcf-rec "$@"'';
+          };
+
           # ── OCI node images (hermetic; built with `nix build .#docker-*`) ──────
           # These run like real nodes, not cert harnesses: each image's entrypoint
           # is the node binary with `start` as the default command.
@@ -318,7 +358,12 @@
 
         devShells = {
           default = pkgs.mkShell {
-            packages = [ protobuf pkgs.cmake pkgs.grpc pkgs.rustc pkgs.cargo pkgs.go pkgs.nodejs pkgs.python3 pkgs.perl pkgs.sbcl ];
+            packages = [
+              protobuf pkgs.cmake pkgs.grpc pkgs.rustc pkgs.cargo pkgs.go
+              pkgs.nodejs pkgs.python3 pkgs.perl pkgs.sbcl
+              # DCF-Audio -> ffmpeg recording: the `dcf` demuxer + dcf-rec wrapper.
+              self.packages.${system}.dcf-ffmpeg self.packages.${system}.dcf-rec
+            ];
             shellHook = ''
               export PROTOC=${protobuf}/bin/protoc
             '';

--- a/python/MCP/gen_audio_dump.py
+++ b/python/MCP/gen_audio_dump.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-only
+# Copyright (c) 2026 DeMoD LLC.
+"""Generate a ``.dcf`` audio frame-dump for the FFmpeg ``dcf`` demuxer / ``dcf-rec``.
+
+A ``.dcf`` dump is the canonical offline container the ``ff_dcf_demuxer`` reads: a
+**flat concatenation of 17-byte DeModFrames** — exactly the AUDIO-adapter frames
+that ride on the wire (one ``DeModFrame`` per UDP ``MSG_AUDIO`` payload). It is
+self-synchronising (every record starts with sync ``0xD3`` and ends with a
+CRC-16/CCITT over bytes ``[0..14]``), so the demuxer can probe + resync on it.
+
+This tool emits a **byte-deterministic** PCM-diag (codec_id 1) tone so the wire →
+ffmpeg → file path can be certified end-to-end: the bytes the demuxer hands to
+FFmpeg's ``pcm_u8`` decoder are *exactly* the bytes written here. It reuses the
+certified L2 framing (``audiolab_core.packetize``) and PCM-diag codec, so a dump is
+provably the same ``DeModFrame``s the 246-vector wire certificate pins.
+
+Each ``--src`` becomes one audio stream in the demuxer (keyed by the frame ``src``
+id). For each source we also write a sidecar ``<out>.src<ID>.u8`` holding the raw
+unsigned-8 PCM the tone encoded to — the ground truth for a byte-exact round-trip:
+
+    ffmpeg -f dcf -i tone.dcf -map 0:a:0 -f u8 -ac 1 -ar 6000 out.u8
+    cmp out.u8 tone.dcf.src1.u8          # must be identical
+
+Usage:
+    python3 python/MCP/gen_audio_dump.py tone.dcf
+    python3 python/MCP/gen_audio_dump.py two.dcf --src 1 --src 7 --blocks 25
+"""
+import argparse
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import audiolab_core as al  # certified L2 framing + PCM-diag codec
+
+TS_MASK = (1 << 24) - 1  # frame timestamp is 24-bit microseconds
+
+
+def _tone_block(freq, rate, block, phase):
+    """One `block`-sample mono sine block at `freq` Hz, returning (samples, phase)."""
+    samples = []
+    for _ in range(block):
+        samples.append(0.6 * math.sin(phase))
+        phase += 2.0 * math.pi * freq / rate
+    return samples, phase
+
+
+def gen_source(frames_out, pcm_out, src_id, freq, blocks):
+    """Append `blocks` PCM-diag frames for one source; return the raw u8 PCM bytes."""
+    rate, block = al.PCM_DIAG_RATE, al.PCM_DIAG_BLOCK  # 6000 Hz, 120 samples/block
+    phase = 0.0
+    pcm_u8 = bytearray()
+    for pid in range(blocks):
+        samples, phase = _tone_block(freq, rate, block, phase)
+        payload = al.pcm_diag_encode(samples)          # 120 bytes, byte-deterministic
+        pcm_u8 += payload
+        ts_us = (pid * 20_000) & TS_MASK
+        flags = al.FLAG_END_TALKSPURT if pid == blocks - 1 else 0
+        for fr in al.packetize(al.CODEC_PCM_DIAG, payload, pid, ts_us,
+                               src_id, 0xFFFF, flags):
+            frames_out.append((pid, fr))
+    pcm_out[src_id] = bytes(pcm_u8)
+    return pcm_out[src_id]
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("out", help="output .dcf path")
+    ap.add_argument("--src", type=lambda s: int(s, 0), action="append",
+                    metavar="ID", help="source node id (repeatable; default 1)")
+    ap.add_argument("--blocks", type=int, default=50,
+                    help="20 ms blocks per source (default 50 = 1.0 s)")
+    ap.add_argument("--freq", type=float, default=440.0,
+                    help="base tone Hz for the first source (default 440)")
+    ap.add_argument("--no-sidecar", action="store_true",
+                    help="skip writing the per-source raw u8 PCM ground-truth files")
+    args = ap.parse_args(argv)
+
+    srcs = args.src or [1]
+    frames = []          # list of (block_index, 17-byte frame)
+    pcm = {}             # src_id -> raw u8 PCM bytes
+    for i, sid in enumerate(srcs):
+        gen_source(frames, pcm, sid, args.freq * (i + 1), args.blocks)
+
+    # Interleave by block so multiple sources are multiplexed like the live wire.
+    frames.sort(key=lambda bf: bf[0])
+    with open(args.out, "wb") as f:
+        for _, fr in frames:
+            f.write(fr)
+
+    n_audio_frames = len(frames)
+    print(f"wrote {args.out}: {n_audio_frames} frames "
+          f"({n_audio_frames * al.__dict__.get('FRAME_SIZE', 17)} bytes), "
+          f"{len(srcs)} source(s) x {args.blocks} blocks, codec=pcm-diag")
+    if not args.no_sidecar:
+        for sid, raw in pcm.items():
+            side = f"{args.out}.src{sid}.u8"
+            with open(side, "wb") as f:
+                f.write(raw)
+            print(f"  ground truth: {side} ({len(raw)} bytes u8 @ 6000 Hz)")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/dcf/wiretap.py
+++ b/python/dcf/wiretap.py
@@ -104,10 +104,14 @@ external_unwrap = external_wrap
 
 
 class Wiretap:
-    """Transparent capturing UDP relay. Forwards ``bind`` -> ``forward``."""
+    """Transparent capturing UDP relay. Forwards ``bind`` -> ``forward``.
 
-    def __init__(self, bind, forward, on_capture=None, label="wiretap"):
-        self.forward = (forward[0], int(forward[1]))
+    ``forward`` may be ``None`` for a pure passive listener (bind + capture only,
+    no relay) — used by ``dcf-rec listen`` to record audio sent at a bound port.
+    """
+
+    def __init__(self, bind, forward=None, on_capture=None, label="wiretap"):
+        self.forward = (forward[0], int(forward[1])) if forward else None
         self.label = label
         self.on_capture = on_capture
         self.captures = []                     # list of (raw_bytes, src_addr)
@@ -149,11 +153,13 @@ class Wiretap:
             log.info("[%s] %s -> %s : %s", self.label, src, self.forward, summary)
             if self.on_capture:
                 self.on_capture(data, src, summary)
-            # Forward unchanged — a passive tap is transparent to the mesh.
-            try:
-                self._sock.sendto(data, self.forward)
-            except OSError:
-                pass
+            # Forward unchanged — a passive tap is transparent to the mesh. With no
+            # forward configured this is a pure listener (no relay).
+            if self.forward is not None:
+                try:
+                    self._sock.sendto(data, self.forward)
+                except OSError:
+                    pass
 
     def decoded(self):
         """All captures that decode as a DCF ProtoMessage (the recovered plaintext)."""

--- a/python/dcf_node.py
+++ b/python/dcf_node.py
@@ -25,6 +25,7 @@ sys.path.insert(0, __file__.rsplit("/", 1)[0])
 from dcf.udp_node import DcfNode
 from dcf.mesh_runtime import MeshRuntime
 from dcf.wiretap import Wiretap
+from dcf.proto import ProtoMessage, MSG_AUDIO
 
 
 def _split_hostport(s, what):
@@ -65,17 +66,39 @@ def cmd_start(args):
 def cmd_wiretap(args):
     bind = _split_hostport(args.bind, "--bind")
     forward = _split_hostport(args.forward, "--forward")
-    tap = Wiretap(bind, forward, label="wiretap")
+
+    # --dump: append every captured AUDIO frame (one 17-byte DeModFrame per
+    # MSG_AUDIO datagram) to a flat .dcf the `dcf` ffmpeg demuxer / dcf-rec read.
+    dump_f = open(args.dump, "wb") if args.dump else None
+    n_audio = [0]
+
+    def on_capture(data, src, summary):
+        if dump_f is None:
+            return
+        try:
+            msg = ProtoMessage.deserialize(data)
+        except ValueError:
+            return
+        if msg.msg_type == MSG_AUDIO and len(msg.payload) == 17:
+            dump_f.write(msg.payload)
+            n_audio[0] += 1
+
+    tap = Wiretap(bind, forward, on_capture=on_capture, label="wiretap")
     logging.info("wiretap: capturing %s -> %s (plaintext DCF wire; Ctrl-C to stop)",
                  args.bind, args.forward)
+    if dump_f is not None:
+        logging.info("wiretap: dumping AUDIO frames to %s", args.dump)
     tap.start()
     try:
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
-        logging.info("captured %d datagrams", len(tap.captures))
+        logging.info("captured %d datagrams (%d audio frames dumped)",
+                     len(tap.captures), n_audio[0])
     finally:
         tap.stop()
+        if dump_f is not None:
+            dump_f.close()
 
 
 def main(argv=None):
@@ -97,6 +120,8 @@ def main(argv=None):
     w = sub.add_parser("wiretap", help="passively capture + forward the plaintext wire")
     w.add_argument("--bind", required=True, help="listen address host:port")
     w.add_argument("--forward", required=True, help="real destination host:port")
+    w.add_argument("--dump", metavar="FILE.dcf",
+                   help="append captured AUDIO frames to a .dcf for the ffmpeg demuxer")
     w.set_defaults(func=cmd_wiretap)
 
     args = p.parse_args(argv)


### PR DESCRIPTION
Record audio carried over **DeModFrames** into any FFmpeg-supported file type, with a dedicated CLI. DCF-Audio stays an adapter over the certified 17-byte wire quantum — the demuxer reuses the certified C reassembler/frame codec verbatim (`codec/demod_audio.h`, `demod_frame.h`), so it hands FFmpeg exactly the bytes the 246-vector certificate pins. **No wire/cert changes.**

## Native FFmpeg demuxer (`ffmpeg-dcf/dcfdec.c` → `ff_dcf_demuxer`, `"dcf"`)
- One audio stream per peer (frame `src`), tagged `title="peer 0x<id>"`.
- `codec_id` maps onto built-in decoders, so only a demuxer is registered: `0` Opus → `AV_CODEC_ID_OPUS` + `OpusHead` (`-c:a copy` bit-exact); `1` PCM-diag → `pcm_u8 @ 6 kHz`; `2` Faust-PM → synthesised to `pcm_f32le @ 48 kHz`.
- PTS from the unwrapped 11-bit `packet_id` → lost blocks are honest gaps.
- Built into FFmpeg via `flake.nix` (`packages.dcf-ffmpeg`); PM synth compiled through a `-Wmissing-prototypes` shim (`ffmpeg-dcf/dcf_pm_ff.c`).

## `dcf-rec` CLI (Python; reuses `python/MCP` + `python/dcf`)
- **rec** — record by output extension (wav/flac/opus/ogg/mka/mp3/m4a); multi-peer downmix, `.mka` multitrack master; stdin/stdout, default `<stem>.flac`, `--format`.
- **info** — per-peer codec/rate/duration/packet-loss/channels (direct frame scan; `--json`).
- **split** — one file per peer (`peer-0x<id>.<ext>`) for DAW stems.
- **listen** — passive UDP sniffer (strips ProtoMessage envelopes) → record live off the wire; optional `--forward` relay; signal-driven clean shutdown.

## Capture plumbing
- `.dcf` dump = flat 17-byte DeModFrames; `python/MCP/gen_audio_dump.py` emits a byte-deterministic PCM-diag tone (+ ground-truth sidecars).
- `python/dcf_node.py wiretap --dump` writes captured AUDIO frames to a `.dcf`; `Wiretap` forward is now optional (passive capture).

## Verification
dcf demuxer registered · pcm_u8 byte-exact round-trip · Opus `-c:a copy` bit-exact · PM synthesis · multitrack `.mka` · `info` (incl. loss on a lossy dump) · `split` per-peer · stdin + default naming · live `listen` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)