### PR TITLE
cpp: DCF-Steam — Steam-compatible multiplayer transport (GNS + Steamw…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,42 @@ Both ship as hermetic Nix node images: `nix build .#docker-dcf-c` /
 `.#docker-dcf-cpp` (entrypoints `dcfnode start` / `dcfcpp serve`); pushed via
 `docker/build-and-push.sh` and exercised by `docker/mesh-interop-test.sh`.
 
+## DCF-Steam (Steam-compatible multiplayer transport)
+
+A **transport** under the wire (not a new format): `dcfcpp` also speaks Valve's
+`ISteamNetworkingSockets` — Steam **P2P** for clients and **dedicated servers** that
+are the Docker containers / runtime. Spec: `Documentation/DCF_STEAM_SPEC.md`.
+
+- **One API, two backends** (same source recompiles): **GNS** — the open
+  GameNetworkingSockets (BSD-3, nixpkgs `gamenetworkingsockets`), default + hermetic,
+  built/tested in CI; **Steamworks** — the proprietary SDK (opt-in, developer-supplied)
+  adds SDR relay, lobbies, server browser. Backends differ in ~6 calls behind
+  `#if DCF_CPP_STEAM`; the send/recv/hub/framing path is shared, so the GNS build
+  exercises the Steam build's wire logic.
+- **Roles:** `dcfcpp serve-gns` / `serve-steam` = dedicated-server **hub** (forwards
+  each DCF frame to the other clients, preserving reliability); `connect-gns
+  --peer host:port` / `connect-steam --peer <identity>` = client/P2P. Transport
+  datagram = `[flags u8][DCF payload]`, bit0 RELIABLE → `k_nSteamNetworkingSend_Reliable`.
+- **Mappings:** DCF-Game `FLAG_RELIABLE`→reliable send; `dst` channel ↔ lobby;
+  `src_id` ↔ SteamID slot (via `GMSG_JOIN`). Transport crypto (GNS/Steam AES) sits
+  **beneath** the codec — the DCF payload stays plaintext (`DCF_SECURITY_EXPOSURE.md`).
+- **References:** `cpp/include/dcf/{transport,net_steam}.hpp`, `cpp/src/net_steam.cpp`,
+  `cpp/src/steam_{gameserver,lobby}.cpp` (`#ifdef DCF_CPP_STEAM`). Image:
+  `nix build .#docker-dcf-gns` (entrypoint `dcfcpp serve-gns`, `27015/udp`); Steam
+  server image `cpp/Dockerfile.steam` (non-hermetic).
+- **Licensing:** GNS is BSD-3 (redistributable). The **Steamworks SDK is proprietary
+  and NOT redistributable** — never commit/vendor it; only `redistributable_bin/`
+  ships in object form; no `steam_appid.txt` in prod. Enforced by `cpp/.gitignore`
+  and a `DCF_CPP_STEAM` CMake warning.
+
+```sh
+nix build .#dcf-cpp-gns        # open backend (hermetic)
+cd cpp && cmake -B build -DDCF_CPP_GRPC=OFF -DDCF_CPP_GNS=ON \
+  -DDCF_GNS_INCLUDE_DIR=$(nix eval --raw nixpkgs#gamenetworkingsockets)/include/GameNetworkingSockets \
+  -DDCF_GNS_LIB_DIR=$(nix eval --raw nixpkgs#gamenetworkingsockets)/lib && \
+  cmake --build build --target dcfcpp && (cd build && ctest -R gns_loopback)
+```
+
 ## Per-language build & test
 
 | Dir | Build | Test |

--- a/Documentation/DCF_STEAM_SPEC.md
+++ b/Documentation/DCF_STEAM_SPEC.md
@@ -1,0 +1,136 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-only -->
+# DCF-Steam — Steam-compatible multiplayer transport
+
+DCF-Steam makes the DeMoD mesh speak **Valve's multiplayer networking**: Steam
+**P2P** for clients and **dedicated servers** that are the Docker containers / node
+runtime. It is a **transport** under the certified DCF wire — the 17-byte
+`DeModFrame` quantum and every adapter (game/audio/text/superpack) are unchanged;
+DCF-Steam only carries those bytes between peers.
+
+This is implemented in the C++ node (`cpp/`, binary `dcfcpp`).
+
+## One API, two backends
+
+The transport is written **once** against Valve's `ISteamNetworkingSockets` API and
+the backend is chosen at build time. The open and proprietary libraries share the
+**same API and wire protocol**, so the same source recompiles against either:
+
+| Backend | CMake | Library | What you get | Hermetic? |
+|---------|-------|---------|--------------|-----------|
+| **GNS** (default) | `-DDCF_CPP_GNS=ON` | GameNetworkingSockets (BSD-3, nixpkgs) | Dedicated server (`CreateListenSocketIP`), client (`ConnectByIPAddress`), hub forwarding, LAN/direct P2P, custom-signaling P2P | ✅ yes (CI/Docker) |
+| **Steamworks** (priority) | `-DDCF_CPP_STEAM=ON -DDCF_STEAMWORKS_SDK=…` | Proprietary Steamworks SDK | + **SDR relay** (NAT-punch, IP hiding), **lobbies**, **server browser**, Steam auth | ❌ developer-supplied |
+
+Reference: `cpp/include/dcf/{transport,net_steam}.hpp`, `cpp/src/net_steam.cpp`
+(shared), `cpp/src/steam_{gameserver,lobby}.cpp` (`#ifdef DCF_CPP_STEAM`).
+
+The two backends differ in **~6 calls**, isolated behind `#if DCF_CPP_STEAM /
+#else`: init, relay-init, listen (`CreateListenSocketP2P` vs `…IP`), connect
+(`ConnectP2P` vs `ConnectByIPAddress`). The send/receive/poll loop, the hub
+forwarding, and the DCF framing are identical — so the open GNS build **fully
+exercises** the wire and reliability logic that the Steam build also runs.
+
+## Roles
+
+- **Dedicated server (the Docker container / runtime).** `dcfcpp serve-gns`
+  (or `serve-steam`) opens a listen socket + poll group, accepts clients, and
+  **forwards each DCF frame to the other clients** preserving the sender's
+  reliability — a hub. Channel filtering stays the receiver's job (the DCF
+  dst-channel rendezvous), exactly as elsewhere in DCF. Under Steamworks the server
+  also registers with the **master server** (server browser) and may host a lobby.
+- **Client / P2P.** `dcfcpp connect-gns --peer host:port` (direct/LAN/dedicated) or,
+  under Steamworks, `connect-steam --peer <identity>` for **SDR-relayed P2P** (NAT
+  traversal, IP hidden). With open GNS, NAT-punched internet P2P needs either a
+  WebRTC-ICE GNS build (the nixpkgs build ships **without** WebRTC) or the Steam SDR
+  backend; LAN/direct and hub-relayed paths work out of the box.
+
+## Transport datagram
+
+GNS does not report, on receive, whether a message arrived reliably — so a
+forwarding hub could not preserve intent. Each transport message is therefore:
+
+```
+[ flags : u8 ][ DCF payload : N bytes ]      flags bit0 = RELIABLE
+```
+
+The payload is the **unmodified** DCF wire (a 17-byte frame, a 32-byte SuperPack, or
+an adapter burst). The hub reads `flags`, forwards with the matching reliability
+(`k_nSteamNetworkingSend_Reliable` / `_Unreliable`), and leaves the payload intact —
+so the certified wire certificate is untouched.
+
+## Mappings (DCF ↔ Steam)
+
+| DCF | Steam | Notes |
+|-----|-------|-------|
+| DCF-Game `FLAG_RELIABLE`/`ORDERED` descriptor | `k_nSteamNetworkingSend_Reliable` | else `_Unreliable`; the game spec already says these flags "pick the transport path" |
+| `dst` channel (u16 = `crc16(passphrase)`) | **lobby** / virtual port | handshakeless rendezvous ↔ a room/lobby; `0xFFFF` = broadcast/open |
+| `src_id` (u16) | per-player identity | a SteamID64 is carried in a `GMSG_JOIN` and mapped to a u16 slot (collision-checked); `SteamNetworkingIdentity::SetGenericString` holds the node id for GNS |
+| node / hub | `ISteamGameServer` dedicated server | anonymous or GSLT login; master-server heartbeats → server browser |
+| reassembly keyed by `src_id` | per-connection messages | one reassembler per peer, as today |
+
+## Encryption & export control
+
+GameNetworkingSockets and Steam encrypt connections at the **transport** layer
+(AES-GCM / Curve25519). That sits **beneath** the DCF codec — exactly the deployment
+rule in `Documentation/DCF_SECURITY_EXPOSURE.md` ("deploy DCF inside WireGuard / an
+operator-supplied transport crypto beneath the UDP socket — never in the codec").
+The DCF application payload stays plaintext, so the encryption-free codec and its
+EAR/ITAR posture are preserved; DCF-Steam simply gives you the operator-level
+transport crypto that rule already calls for. Do **not** add crypto to the DCF codec.
+
+## Build & run (open GNS — hermetic)
+
+```sh
+nix build .#dcf-cpp-gns                 # or: nix build .#docker-dcf-gns
+cd cpp && cmake -B build -DDCF_CPP_GRPC=OFF -DDCF_CPP_GNS=ON \
+  -DDCF_GNS_INCLUDE_DIR=$(nix eval --raw nixpkgs#gamenetworkingsockets)/include/GameNetworkingSockets \
+  -DDCF_GNS_LIB_DIR=$(nix eval --raw nixpkgs#gamenetworkingsockets)/lib
+cmake --build build --target dcfcpp && (cd build && ctest -R gns_loopback)
+
+# dedicated server + two clients
+dcfcpp serve-gns --port 27015
+dcfcpp connect-gns --peer 127.0.0.1:27015 --listen 5                       # receiver
+dcfcpp connect-gns --peer 127.0.0.1:27015 --send-hex <FRAME> --reliable    # sender
+```
+
+The nixpkgs `gamenetworkingsockets` CMake export has a doubled include path and a
+dangling `protobuf::libprotobuf` in its link interface, so the build links the
+library directly (`DCF_GNS_INCLUDE_DIR` / `DCF_GNS_LIB_DIR`) instead of relying on
+`find_package` — the GNS `.so` resolves protobuf/openssl via rpath.
+
+## Build & run (Steamworks — developer-supplied)
+
+```sh
+# 1. Download the Steamworks SDK under YOUR partner account; put it at
+#    cpp/steamworks_sdk/ (gitignored). Create an App ID + dedicated-server App ID.
+cmake -S cpp -B cpp/build-steam -DDCF_CPP_GRPC=OFF -DDCF_CPP_STEAM=ON \
+  -DDCF_STEAMWORKS_SDK=$PWD/cpp/steamworks_sdk
+cmake --build cpp/build-steam --target dcfcpp
+# 2. dedicated server (anonymous or GSLT via $DCF_STEAM_GSLT); image: cpp/Dockerfile.steam
+DCF_STEAM_GSLT=<token> dcfcpp serve-steam --port 16000 --node-id my-server
+```
+
+To verify SDR P2P, lobby create/join, and server-browser registration you need
+**your** Steamworks SDK, an **App ID**, a `steam_appid.txt` (dev only), and a
+**GSLT** (or anonymous login). Those are not present in this repo or CI, so the
+Steam backend is **compile-guarded and unverified here**; the shared transport is
+verified by the GNS `gns_loopback` test.
+
+## Licensing
+
+**This repository contains no Steamworks SDK material** — no Valve headers, no
+libraries, no `steam_appid.txt`. The Steam backend (`cpp/src/steam_*.cpp`,
+`net_steam.cpp`'s `#if DCF_CPP_STEAM` branches) is original LGPL-3.0 source that
+*links* a developer-supplied SDK; it only references Valve's published API (writing
+interoperable code), never copies Valve's declarations, and is excluded from the
+default open build.
+
+- **GameNetworkingSockets** — BSD-3-Clause; freely linkable from the LGPL-3.0 node,
+  and packaged in nixpkgs. This is the default, redistributable backend.
+- **Steamworks SDK** — proprietary, under the **Steamworks SDK Access Agreement**.
+  It is **not redistributable**: do **not** commit or vendor the SDK source/headers.
+  Only the contents of `redistributable_bin/` (`libsteam_api.so`, `steamclient.so`)
+  may ship **in object form** with your built server — which is exactly what
+  `cpp/Dockerfile.steam` bundles. Do **not** ship `steam_appid.txt` in a production
+  image. `cpp/.gitignore` enforces this (SDK dirs, `steam_appid.txt`,
+  `redistributable_bin/` are ignored), and the CMake `DCF_CPP_STEAM` path prints the
+  same reminder. Each developer supplies the SDK under their own partner account.

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,0 +1,14 @@
+# Steamworks SDK Access Agreement: the proprietary SDK is NOT redistributable and
+# must never be committed/vendored. Keep developer-supplied SDK + build artifacts
+# out of the repo. Only `redistributable_bin/` may SHIP (in object form) with a
+# built server image — not in source control. See Documentation/DCF_STEAM_SPEC.md.
+steamworks_sdk/
+steamworks-sdk/
+sdk/
+**/steam_appid.txt
+redistributable_bin/
+*.acf
+
+# CMake build trees
+build/
+build-*/

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,6 +6,14 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(DCF_CPP_GRPC "Build the dcfcpp gRPC node (needs gRPC + protobuf)" ON)
+option(DCF_CPP_GNS  "Build the Steam-compatible transport on GameNetworkingSockets" OFF)
+option(DCF_CPP_STEAM "Build against the proprietary Steamworks SDK (SDR relay + lobbies)" OFF)
+# Developer-supplied Steamworks SDK root (the `sdk/` dir) — required for DCF_CPP_STEAM.
+set(DCF_STEAMWORKS_SDK "" CACHE PATH "Path to the Steamworks SDK (sdk/) for DCF_CPP_STEAM")
+
+if(DCF_CPP_GNS AND DCF_CPP_STEAM)
+    message(FATAL_ERROR "DCF_CPP_GNS and DCF_CPP_STEAM are mutually exclusive backends")
+endif()
 
 # Header-only wire codec (frame.hpp + superpack.hpp).
 add_library(dcf_wire INTERFACE)
@@ -22,32 +30,81 @@ target_link_libraries(certify_superpack PRIVATE dcf_wire)
 add_test(NAME certify_superpack COMMAND certify_superpack
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-# ── Supercharged gRPC node ───────────────────────────────────────────────────
-if(DCF_CPP_GRPC)
+# ── dcfcpp node: gRPC and/or Steam-compatible (GNS / Steamworks) transports ──
+if(DCF_CPP_GRPC OR DCF_CPP_GNS OR DCF_CPP_STEAM)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
-    find_package(Protobuf CONFIG REQUIRED)
-    find_package(gRPC CONFIG REQUIRED)
-
-    add_library(dcf_proto STATIC proto/dcf.proto)
-    target_link_libraries(dcf_proto PUBLIC protobuf::libprotobuf gRPC::grpc++)
-    target_include_directories(dcf_proto PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
-
-    protobuf_generate(TARGET dcf_proto LANGUAGE cpp
-        IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/proto
-        PROTOC_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-    protobuf_generate(TARGET dcf_proto LANGUAGE grpc
-        GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
-        PLUGIN "protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
-        IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/proto
-        PROTOC_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
     add_executable(dcfcpp src/dcf_node.cpp)
     target_include_directories(dcfcpp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-    target_link_libraries(dcfcpp PRIVATE
-        dcf_proto dcf_wire protobuf::libprotobuf
-        gRPC::grpc++ gRPC::grpc++_reflection)
+    target_link_libraries(dcfcpp PRIVATE dcf_wire Threads::Threads)
+
+    # gRPC transport (legacy): unary SendFrame + bidi MeshStream.
+    if(DCF_CPP_GRPC)
+        find_package(Protobuf CONFIG REQUIRED)
+        find_package(gRPC CONFIG REQUIRED)
+        add_library(dcf_proto STATIC proto/dcf.proto)
+        target_link_libraries(dcf_proto PUBLIC protobuf::libprotobuf gRPC::grpc++)
+        target_include_directories(dcf_proto PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
+        protobuf_generate(TARGET dcf_proto LANGUAGE cpp
+            IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/proto
+            PROTOC_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+        protobuf_generate(TARGET dcf_proto LANGUAGE grpc
+            GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
+            PLUGIN "protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
+            IMPORT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/proto
+            PROTOC_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+        target_compile_definitions(dcfcpp PRIVATE DCF_CPP_GRPC)
+        target_link_libraries(dcfcpp PRIVATE
+            dcf_proto protobuf::libprotobuf gRPC::grpc++ gRPC::grpc++_reflection)
+    endif()
+
+    # Steam-compatible transport on the open GameNetworkingSockets (BSD-3).
+    if(DCF_CPP_GNS)
+        target_sources(dcfcpp PRIVATE src/net_steam.cpp)
+        target_compile_definitions(dcfcpp PRIVATE DCF_CPP_GNS)
+        # The nixpkgs GameNetworkingSockets CMake config has a doubled include path
+        # and a dangling protobuf target in its link interface, so we link the lib
+        # directly (its .so resolves protobuf/openssl via rpath). The flake passes
+        # DCF_GNS_INCLUDE_DIR / DCF_GNS_LIB_DIR; otherwise fall back to find_package.
+        if(DCF_GNS_INCLUDE_DIR)
+            target_include_directories(dcfcpp PRIVATE ${DCF_GNS_INCLUDE_DIR})
+        endif()
+        find_library(DCF_GNS_LIB NAMES GameNetworkingSockets HINTS ${DCF_GNS_LIB_DIR})
+        if(DCF_GNS_LIB)
+            target_link_libraries(dcfcpp PRIVATE ${DCF_GNS_LIB})
+        else()
+            find_package(GameNetworkingSockets CONFIG REQUIRED)
+            target_link_libraries(dcfcpp PRIVATE GameNetworkingSockets::GameNetworkingSockets)
+        endif()
+    endif()
+
+    # Proprietary Steamworks backend (SDR relay + lobbies + server browser).
+    # Developer-supplied SDK; not redistributable / not in CI. See DCF_STEAM_SPEC.md.
+    if(DCF_CPP_STEAM)
+        if(NOT DCF_STEAMWORKS_SDK)
+            message(FATAL_ERROR "DCF_CPP_STEAM requires -DDCF_STEAMWORKS_SDK=/path/to/sdk")
+        endif()
+        message(WARNING
+            "Building against the proprietary Steamworks SDK at ${DCF_STEAMWORKS_SDK}.\n"
+            "  Steamworks SDK Access Agreement: the SDK is NOT redistributable. Do not\n"
+            "  commit/vendor it. Only redistributable_bin/ (libsteam_api.so, steamclient.so)\n"
+            "  may ship, in object form, with the built node. Do not ship steam_appid.txt in\n"
+            "  production. See Documentation/DCF_STEAM_SPEC.md (Licensing).")
+        target_sources(dcfcpp PRIVATE src/net_steam.cpp src/steam_gameserver.cpp src/steam_lobby.cpp)
+        target_compile_definitions(dcfcpp PRIVATE DCF_CPP_STEAM)
+        target_include_directories(dcfcpp PRIVATE ${DCF_STEAMWORKS_SDK}/public)
+        find_library(STEAM_API_LIB NAMES steam_api libsteam_api
+            PATHS ${DCF_STEAMWORKS_SDK}/redistributable_bin/linux64 REQUIRED)
+        target_link_libraries(dcfcpp PRIVATE ${STEAM_API_LIB})
+    endif()
 
     include(GNUInstallDirs)
     install(TARGETS dcfcpp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    # Hub <-> 2-client forwarding test (only the open GNS build runs in CI).
+    if(DCF_CPP_GNS)
+        add_test(NAME gns_loopback
+            COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/gns_loopback.sh $<TARGET_FILE:dcfcpp>)
+    endif()
 endif()

--- a/cpp/Dockerfile.steam
+++ b/cpp/Dockerfile.steam
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# Steamworks dedicated-server image for dcfcpp (SDR relay + server browser + lobbies).
+# This is NOT hermetic and is NOT a flake output, because the Steamworks SDK is
+# proprietary and may not be redistributed (see Documentation/DCF_STEAM_SPEC.md).
+#
+# ── Steamworks SDK Access Agreement — your obligations ───────────────────────
+#   • You must download the Steamworks SDK yourself under your partner account.
+#   • Do NOT commit/vendor the SDK source. Only the contents of
+#     `redistributable_bin/` (libsteam_api.so, steamclient.so) may ship, in object
+#     form, with the built server — which is exactly what this image bundles.
+#   • Do NOT ship `steam_appid.txt` in a production image (it is for local dev only;
+#     the depot supplies the App ID at runtime). `.gitignore` already excludes both.
+#
+# ── Build (developer-supplied SDK; from the repo root) ───────────────────────
+#   # 1. put the SDK at cpp/steamworks_sdk/ (its `public/` + `redistributable_bin/`)
+#   # 2. build dcfcpp with the Steam backend:
+#   #    cmake -S cpp -B cpp/build-steam -DDCF_CPP_GRPC=OFF -DDCF_CPP_STEAM=ON \
+#   #          -DDCF_STEAMWORKS_SDK=$PWD/cpp/steamworks_sdk
+#   #    cmake --build cpp/build-steam --target dcfcpp
+#   # 3. docker build -f cpp/Dockerfile.steam \
+#   #       --build-arg SDK=cpp/steamworks_sdk -t dcf-steam .
+#
+# ── Run (dedicated server) ───────────────────────────────────────────────────
+#   docker run -e DCF_STEAM_GSLT=<your-login-token> -p 16000:16000/udp dcf-steam \
+#     serve-steam --port 16000 --node-id my-server
+#   # omit DCF_STEAM_GSLT to use anonymous login.
+
+FROM debian:bookworm-slim
+
+ARG SDK=cpp/steamworks_sdk
+ARG BUILD=cpp/build-steam
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libc6 ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Only the redistributable binaries — never the SDK source/headers.
+COPY ${SDK}/redistributable_bin/linux64/ /usr/lib/dcf-steam/
+COPY ${BUILD}/dcfcpp /usr/local/bin/dcfcpp
+
+ENV LD_LIBRARY_PATH=/usr/lib/dcf-steam
+EXPOSE 16000/udp
+ENTRYPOINT ["/usr/local/bin/dcfcpp"]
+CMD ["serve-steam", "--port", "16000"]

--- a/cpp/include/dcf/net_steam.hpp
+++ b/cpp/include/dcf/net_steam.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+#ifndef DCF_NET_STEAM_HPP
+#define DCF_NET_STEAM_HPP
+
+// SteamNet — a DCF transport over Valve's ISteamNetworkingSockets API.
+//
+// The SAME source compiles against two backends, selected at build time:
+//   • DCF_CPP_GNS   (default, open, hermetic): Valve's GameNetworkingSockets.
+//                   Dedicated server via CreateListenSocketIP; client via
+//                   ConnectByIPAddress. P2P NAT-traversal needs the WebRTC/ICE GNS
+//                   build or the Steam backend below.
+//   • DCF_CPP_STEAM (opt-in, developer-supplied Steamworks SDK): adds SDR relay
+//                   (CreateListenSocketP2P / ConnectP2P), lobbies, server browser.
+//
+// Steam handles (HSteamListenSocket / HSteamNetConnection / HSteamNetPollGroup) are
+// uint32 typedefs; we store them as plain integers so this header never needs the
+// Steam SDK headers. See Documentation/DCF_STEAM_SPEC.md.
+
+#include "dcf/transport.hpp"
+
+#include <string>
+#include <vector>
+
+namespace dcf {
+
+class SteamNet : public ITransport {
+public:
+    explicit SteamNet(std::string identity = "dcf-node");
+    ~SteamNet() override;
+
+    SteamNet(const SteamNet&) = delete;
+    SteamNet& operator=(const SteamNet&) = delete;
+
+    bool listen(std::uint16_t port) override;
+    ConnId connect(const std::string& host, std::uint16_t port) override;
+    bool send(ConnId c, const void* data, std::size_t len, bool reliable) override;
+    int broadcast_except(ConnId except, const void* data, std::size_t len, bool reliable) override;
+    void poll(std::vector<NetMessage>& out) override;
+    std::vector<ConnId> connections() const override { return conns_; }
+    void close(ConnId c) override;
+
+    bool ok() const { return ok_; }
+    bool is_server() const { return server_; }
+    // Client side: the single outbound connection, and whether it has connected.
+    ConnId client_conn() const { return client_conn_; }
+    bool client_connected() const { return client_connected_; }
+
+    // Invoked by the static connection-status trampoline; arg is a
+    // SteamNetConnectionStatusChangedCallback_t* (opaque here).
+    void on_conn_status(void* info);
+
+private:
+    void drain(std::vector<NetMessage>& out);
+
+    std::string identity_;
+    bool ok_ = false;
+    bool server_ = false;
+    std::uint32_t listen_sock_ = 0;   // HSteamListenSocket  (0 == invalid)
+    std::uint32_t poll_group_ = 0;    // HSteamNetPollGroup
+    ConnId client_conn_ = 0;
+    bool client_connected_ = false;
+    std::vector<ConnId> conns_;       // accepted (server) or outbound (client)
+};
+
+}  // namespace dcf
+
+#endif  // DCF_NET_STEAM_HPP

--- a/cpp/include/dcf/steam_ext.hpp
+++ b/cpp/include/dcf/steam_ext.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+#ifndef DCF_STEAM_EXT_HPP
+#define DCF_STEAM_EXT_HPP
+
+// Steamworks-only extensions (dedicated game server + matchmaking lobbies). These
+// are compiled ONLY when DCF_CPP_STEAM is defined and a developer-supplied
+// Steamworks SDK is on the include/link path (Valve's SDK is proprietary and not
+// redistributable — see Documentation/DCF_STEAM_SPEC.md). The hermetic GNS build
+// never includes this. The networking transport itself lives in net_steam.cpp; the
+// SAME ISteamNetworkingSockets code links against either backend.
+//
+// Mapping: a Steam lobby ↔ a DCF dst channel; a SteamID ↔ a per-player identity.
+
+#if defined(DCF_CPP_STEAM)
+
+#include <cstdint>
+
+namespace dcf {
+
+// Dedicated game server: anonymous (or GSLT, via $DCF_STEAM_GSLT) login + master-
+// server heartbeats so the node appears in the Steam server browser. Call before
+// listen(); pump steam_server_run_callbacks() each tick. Needs steam_appid.txt.
+bool steam_server_register(const char* node_id, std::uint16_t game_port);
+void steam_server_run_callbacks();
+void steam_server_shutdown();
+
+// Matchmaking lobby helpers (results arrive via Steam callbacks; pump them).
+std::uint64_t steam_lobby_create(int max_members);
+bool steam_lobby_join(std::uint64_t lobby_id);
+void steam_lobby_set_data(std::uint64_t lobby_id, const char* key, const char* val);
+
+}  // namespace dcf
+
+#endif  // DCF_CPP_STEAM
+#endif  // DCF_STEAM_EXT_HPP

--- a/cpp/include/dcf/transport.hpp
+++ b/cpp/include/dcf/transport.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+#ifndef DCF_TRANSPORT_HPP
+#define DCF_TRANSPORT_HPP
+
+// A minimal transport seam for the DCF C++ node. The wire (17-byte DeModFrame and
+// its adapters) is unchanged; a transport just carries those bytes between peers.
+// One implementation, SteamNet (net_steam.hpp), targets Valve's
+// ISteamNetworkingSockets API — built against the open GameNetworkingSockets
+// (DCF_CPP_GNS) or, opt-in, the proprietary Steamworks SDK (DCF_CPP_STEAM) for SDR
+// relay / lobbies. See Documentation/DCF_STEAM_SPEC.md.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dcf {
+
+// A connection handle (HSteamNetConnection under the hood; 0 == invalid).
+using ConnId = std::uint32_t;
+
+// A payload received from a peer, with the reliability it was sent with.
+struct NetMessage {
+    ConnId from = 0;
+    std::string data;        // DCF bytes (frame / superpack / adapter), prefix stripped
+    bool reliable = false;
+};
+
+// ── DCF-Steam transport datagram ─────────────────────────────────────────────
+// GNS does not expose, on receive, whether a message arrived reliably — so a
+// forwarding hub could not preserve the sender's intent. We prepend one flags
+// byte: [flags u8][payload...], flags bit0 = RELIABLE. This is a transport-internal
+// envelope (documented in DCF_STEAM_SPEC.md); the payload is the unmodified DCF wire.
+namespace td {
+constexpr std::uint8_t FLAG_RELIABLE = 0x01;
+
+inline std::string wrap(const void* p, std::size_t n, bool reliable) {
+    std::string s;
+    s.reserve(n + 1);
+    s.push_back(reliable ? static_cast<char>(FLAG_RELIABLE) : 0);
+    s.append(reinterpret_cast<const char*>(p), n);
+    return s;
+}
+}  // namespace td
+
+class ITransport {
+public:
+    virtual ~ITransport() = default;
+
+    // Dedicated server / hub: listen for inbound connections on a port (IP port for
+    // GNS; SDR virtual port for Steam).
+    virtual bool listen(std::uint16_t port) = 0;
+
+    // Client: connect to host:port (GNS) or peer identity@virtual-port (Steam).
+    virtual ConnId connect(const std::string& host, std::uint16_t port) = 0;
+
+    virtual bool send(ConnId c, const void* data, std::size_t len, bool reliable) = 0;
+
+    // Hub fan-out: send to every connection except `except`. Returns count sent.
+    virtual int broadcast_except(ConnId except, const void* data, std::size_t len, bool reliable) = 0;
+
+    // Pump transport callbacks and drain any received messages into `out`.
+    virtual void poll(std::vector<NetMessage>& out) = 0;
+
+    virtual std::vector<ConnId> connections() const = 0;
+    virtual void close(ConnId c) = 0;
+};
+
+}  // namespace dcf
+
+#endif  // DCF_TRANSPORT_HPP

--- a/cpp/src/dcf_node.cpp
+++ b/cpp/src/dcf_node.cpp
@@ -1,32 +1,27 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 //
-// C++ supercharged gRPC DCF node — server, client, and CLI. See dcf/dcf_node.hpp.
+// dcfcpp — the C++ DCF node. Two transports, selected at build time:
+//   • gRPC  (DCF_CPP_GRPC): unary SendFrame, bidi MeshStream, Ping/RTT (legacy).
+//   • Steam (DCF_CPP_GNS / DCF_CPP_STEAM): ISteamNetworkingSockets — a dedicated
+//     server "hub" + clients, the Steam-compatible multiplayer transport.
+// See dcf/dcf_node.hpp and Documentation/DCF_STEAM_SPEC.md.
 
 #include "dcf/dcf_node.hpp"
 
+#include <atomic>
 #include <chrono>
+#include <csignal>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/health_check_service_interface.h>
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
-
-#include "dcf.grpc.pb.h"
 #include "dcf/frame.hpp"
 #include "dcf/superpack.hpp"
-
-using grpc::Channel;
-using grpc::ClientContext;
-using grpc::Server;
-using grpc::ServerBuilder;
-using grpc::ServerContext;
-using grpc::ServerReaderWriter;
-using grpc::ServerWriter;
-using grpc::Status;
 
 static uint64_t now_us() {
     using namespace std::chrono;
@@ -40,6 +35,17 @@ static std::string from_hex(const std::string& h) {
     return out;
 }
 
+static std::string to_hex(const std::string& b) {
+    static const char* k = "0123456789abcdef";
+    std::string out;
+    out.reserve(b.size() * 2);
+    for (unsigned char c : b) {
+        out.push_back(k[c >> 4]);
+        out.push_back(k[c & 0xF]);
+    }
+    return out;
+}
+
 static std::string golden_frame() {
     dcf::Frame f;
     f.version = 1; f.type = 3; f.seq = 0x1234; f.src = 1; f.dst = dcf::BROADCAST;
@@ -47,6 +53,22 @@ static std::string golden_frame() {
     auto b = f.encode();
     return std::string(reinterpret_cast<const char*>(b.data()), b.size());
 }
+
+// ════════════════════════════ gRPC transport (legacy) ════════════════════════
+#if defined(DCF_CPP_GRPC)
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+#include "dcf.grpc.pb.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::ServerReaderWriter;
+using grpc::ServerWriter;
+using grpc::Status;
 
 // Validate + describe an envelope's certified payload (frame / superpack).
 static std::string describe(const dcf::Envelope& e) {
@@ -67,7 +89,6 @@ static std::string describe(const dcf::Envelope& e) {
     return "payload (" + std::to_string(p.size()) + " bytes)";
 }
 
-// ── Server ──────────────────────────────────────────────────────────────────
 class DCFServiceImpl final : public dcf::DCFService::Service {
 public:
     explicit DCFServiceImpl(std::string node_id) : node_id_(std::move(node_id)) {}
@@ -88,7 +109,6 @@ public:
 
     Status Subscribe(ServerContext*, const dcf::Subscription* sub,
                      ServerWriter<dcf::Envelope>* writer) override {
-        // Minimal: emit a single heartbeat frame so subscribers see the certified wire.
         dcf::Envelope e;
         e.set_kind(dcf::KIND_FRAME);
         e.set_node_id(node_id_);
@@ -100,7 +120,6 @@ public:
         return Status::OK;
     }
 
-    // The supercharged path: bidirectional streaming mesh.
     Status MeshStream(ServerContext*, ServerReaderWriter<dcf::Envelope, dcf::Envelope>* stream) override {
         dcf::Envelope in;
         while (stream->Read(&in)) {
@@ -114,7 +133,7 @@ public:
                 std::printf("[server] mesh recv from %s: %s\n", in.node_id().c_str(), describe(in).c_str());
                 std::fflush(stdout);
                 out.set_kind(in.kind());
-                out.set_payload(in.payload());  // echo the certified bytes back
+                out.set_payload(in.payload());
             }
             if (!stream->Write(out)) break;
         }
@@ -151,14 +170,12 @@ int run_client(const std::string& peer, const std::string& node_id) {
     ClientContext ctx;
     auto stream = stub->MeshStream(&ctx);
 
-    // 1) PING for RTT
     Envelope ping;
     ping.set_kind(KIND_PING);
     ping.set_node_id(node_id);
     ping.set_timestamp(now_us());
     stream->Write(ping);
 
-    // 2) a certified frame, 3) a SuperPack (two frames)
     std::string frame = golden_frame();
     Envelope fe; fe.set_kind(KIND_FRAME); fe.set_node_id(node_id); fe.set_timestamp(now_us()); fe.set_payload(frame);
     stream->Write(fe);
@@ -220,21 +237,154 @@ int bench(const std::string& peer, int count) {
 }
 
 }  // namespace dcf
+#endif  // DCF_CPP_GRPC
 
-// ── CLI ─────────────────────────────────────────────────────────────────────
+// ═══════════════════════ Steam-compatible transport (GNS / Steamworks) ════════
+#if defined(DCF_CPP_GNS) || defined(DCF_CPP_STEAM)
+#include "dcf/net_steam.hpp"
+#if defined(DCF_CPP_STEAM)
+#include "dcf/steam_ext.hpp"
+#endif
+
+static std::atomic<bool> g_running{true};
+static void on_sigint(int) { g_running = false; }
+
+namespace dcf {
+
+// Dedicated server / hub: accept clients and forward each DCF frame to the others,
+// preserving the sender's reliability. Channel filtering is the receiver's job
+// (the DCF dst-channel rendezvous), exactly as elsewhere in DCF.
+int run_gns_server(uint16_t port, const std::string& node_id, bool steam) {
+    SteamNet net(node_id);
+    if (!net.ok()) return 1;
+#if defined(DCF_CPP_STEAM)
+    if (steam) steam_server_register(node_id.c_str(), port);
+#endif
+    if (!net.listen(port)) { std::fprintf(stderr, "[hub] listen on %u failed\n", port); return 1; }
+    std::signal(SIGINT, on_sigint);
+    std::signal(SIGTERM, on_sigint);
+    std::printf("dcfcpp %s hub on port %u as %s — forwarding DCF frames by channel\n",
+                steam ? "serve-steam (SDR)" : "serve-gns", port, node_id.c_str());
+    std::fflush(stdout);
+
+    std::vector<NetMessage> in;
+    uint64_t frames = 0;
+    while (g_running) {
+        in.clear();
+        net.poll(in);
+#if defined(DCF_CPP_STEAM)
+        if (steam) steam_server_run_callbacks();  // master-server heartbeats
+#endif
+        for (auto& m : in) {
+            const int fwd = net.broadcast_except(m.from, m.data.data(), m.data.size(), m.reliable);
+            uint16_t dst = 0;
+            const char* what = "payload";
+            if (m.data.size() == dcf::FRAME_SIZE) {
+                try {
+                    auto f = dcf::decode(reinterpret_cast<const uint8_t*>(m.data.data()), m.data.size());
+                    dst = f.dst; what = "frame";
+                } catch (...) { what = "invalid"; }
+            } else if (m.data.size() == dcf::SUPER_LEN) {
+                what = "superpack";
+            }
+            std::printf("[hub] %s %zuB dst=0x%04X %s from #%u -> %d peer(s)\n",
+                        what, m.data.size(), dst, m.reliable ? "rel" : "unrel",
+                        (unsigned)m.from, fwd);
+            std::fflush(stdout);
+            ++frames;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+#if defined(DCF_CPP_STEAM)
+    if (steam) steam_server_shutdown();
+#endif
+    std::printf("[hub] stopped after %llu frame(s)\n", (unsigned long long)frames);
+    return 0;
+}
+
+// Client: connect to a hub (GNS host:port, or Steam peer identity), optionally send
+// one DCF frame, and print frames received for `listen_secs`.
+int run_gns_client(const std::string& peer, const std::string& node_id,
+                   const std::string& send_hex, bool reliable, int listen_secs, bool steam) {
+    std::string host = peer;
+    uint16_t port = 0;
+    if (!steam) {
+        auto pos = peer.rfind(':');
+        if (pos == std::string::npos) { std::fprintf(stderr, "[client] --peer must be host:port\n"); return 2; }
+        host = peer.substr(0, pos);
+        port = (uint16_t)std::atoi(peer.substr(pos + 1).c_str());
+    }
+    SteamNet net(node_id);
+    if (!net.ok()) return 1;
+    ConnId c = net.connect(host, port);
+    if (!c) { std::fprintf(stderr, "[client] connect to %s failed\n", peer.c_str()); return 1; }
+
+    const std::string frame = send_hex.empty() ? std::string() : from_hex(send_hex);
+    bool sent = send_hex.empty();
+    std::vector<NetMessage> in;
+    const uint64_t t0 = now_us();
+    int received = 0;
+    while ((now_us() - t0) < (uint64_t)listen_secs * 1000000ULL) {
+        in.clear();
+        net.poll(in);
+        for (auto& m : in) {
+            ++received;
+            std::printf("[client %s] recv %zuB %s: %s\n", node_id.c_str(), m.data.size(),
+                        m.reliable ? "rel" : "unrel", to_hex(m.data).c_str());
+            std::fflush(stdout);
+        }
+        if (!sent && net.client_connected()) {
+            if (net.send(c, frame.data(), frame.size(), reliable)) {
+                std::printf("[client %s] sent %zuB %s: %s\n", node_id.c_str(), frame.size(),
+                            reliable ? "rel" : "unrel", send_hex.c_str());
+                std::fflush(stdout);
+                sent = true;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    std::printf("[client %s] done: %d frame(s) received\n", node_id.c_str(), received);
+    return sent ? 0 : 1;
+}
+
+}  // namespace dcf
+#endif  // DCF_CPP_GNS || DCF_CPP_STEAM
+
+// ════════════════════════════════════ CLI ════════════════════════════════════
 static const char* opt(int argc, char** argv, const char* key, const char* def) {
     for (int i = 0; i < argc; i++)
         if (std::string(argv[i]) == key && i + 1 < argc) return argv[i + 1];
     return def;
 }
 
+static bool has_flag(int argc, char** argv, const char* key) {
+    for (int i = 0; i < argc; i++)
+        if (std::string(argv[i]) == key) return true;
+    return false;
+}
+
 static void print_usage() {
+    std::printf("dcfcpp 0.3.0 — DCF C++ node (DeModFrame + SuperPack)\n");
+#if defined(DCF_CPP_GRPC)
     std::printf(
-        "dcfcpp 0.3.0 — DCF C++ gRPC node (DeModFrame + SuperPack over gRPC bidi MeshStream)\n"
-        "  serve      [--port 50051] [--node-id ID]\n"
-        "  connect    --peer host:port [--node-id ID]\n"
-        "  send-frame --peer host:port [--hex BYTES]\n"
-        "  bench      --peer host:port [--count 100]\n");
+        "  gRPC transport:\n"
+        "    serve      [--port 50051] [--node-id ID]\n"
+        "    connect    --peer host:port [--node-id ID]\n"
+        "    send-frame --peer host:port [--hex BYTES]\n"
+        "    bench      --peer host:port [--count 100]\n");
+#endif
+#if defined(DCF_CPP_GNS) || defined(DCF_CPP_STEAM)
+    std::printf(
+        "  Steam-compatible transport (GameNetworkingSockets):\n"
+        "    serve-gns     [--port 27015] [--node-id ID]            (dedicated server / hub)\n"
+        "    connect-gns   --peer host:port [--send-hex BYTES] [--reliable] [--listen SECS]\n");
+#endif
+#if defined(DCF_CPP_STEAM)
+    std::printf(
+        "  Steamworks (SDR relay + lobbies; needs the Steamworks SDK build):\n"
+        "    serve-steam   [--port 16000] [--node-id ID]\n"
+        "    connect-steam --peer IDENTITY [--send-hex BYTES] [--reliable] [--listen SECS]\n");
+#endif
 }
 
 int main(int argc, char** argv) {
@@ -245,10 +395,11 @@ int main(int argc, char** argv) {
         return 0;
     }
     int rc = argc - 2; char** ra = argv + 2;
-    if (cmd == "serve") {
-        std::string port = opt(rc, ra, "--port", "50051");
-        return dcf::run_server("0.0.0.0:" + port, opt(rc, ra, "--node-id", "dcfcpp-node"));
-    }
+
+#if defined(DCF_CPP_GRPC)
+    if (cmd == "serve")
+        return dcf::run_server("0.0.0.0:" + std::string(opt(rc, ra, "--port", "50051")),
+                               opt(rc, ra, "--node-id", "dcfcpp-node"));
     if (cmd == "connect") {
         const char* peer = opt(rc, ra, "--peer", nullptr);
         if (!peer) { std::fprintf(stderr, "--peer required\n"); return 2; }
@@ -264,6 +415,24 @@ int main(int argc, char** argv) {
         if (!peer) { std::fprintf(stderr, "--peer required\n"); return 2; }
         return dcf::bench(peer, std::atoi(opt(rc, ra, "--count", "100")));
     }
-    std::fprintf(stderr, "unknown command %s\n", cmd.c_str());
+#endif
+
+#if defined(DCF_CPP_GNS) || defined(DCF_CPP_STEAM)
+    if (cmd == "serve-gns" || cmd == "serve-steam") {
+        const bool steam = (cmd == "serve-steam");
+        return dcf::run_gns_server((uint16_t)std::atoi(opt(rc, ra, "--port", steam ? "16000" : "27015")),
+                                   opt(rc, ra, "--node-id", "dcfcpp-hub"), steam);
+    }
+    if (cmd == "connect-gns" || cmd == "connect-steam") {
+        const bool steam = (cmd == "connect-steam");
+        const char* peer = opt(rc, ra, "--peer", steam ? nullptr : "127.0.0.1:27015");
+        if (!peer) { std::fprintf(stderr, "--peer required\n"); return 2; }
+        return dcf::run_gns_client(peer, opt(rc, ra, "--node-id", "dcfcpp-client"),
+                                   opt(rc, ra, "--send-hex", ""), has_flag(rc, ra, "--reliable"),
+                                   std::atoi(opt(rc, ra, "--listen", "2")), steam);
+    }
+#endif
+
+    std::fprintf(stderr, "unknown or unavailable command: %s\n", cmd.c_str());
     return 2;
 }

--- a/cpp/src/net_steam.cpp
+++ b/cpp/src/net_steam.cpp
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// SteamNet — DCF transport over Valve's ISteamNetworkingSockets. One source, two
+// backends (DCF_CPP_GNS open / DCF_CPP_STEAM proprietary). See net_steam.hpp and
+// Documentation/DCF_STEAM_SPEC.md.
+
+#include "dcf/net_steam.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+#if defined(DCF_CPP_STEAM)
+// Proprietary Steamworks SDK (developer-supplied; see DCF_STEAM_SPEC.md). The
+// SteamAPI/SteamGameServer context is initialised by the gameserver/lobby modules;
+// here we only use the networking sockets + relay.
+#include <steam/steam_api.h>
+#include <steam/isteamnetworkingsockets.h>
+#include <steam/isteamnetworkingutils.h>
+#include <steam/steamnetworkingtypes.h>
+#else
+// Open GameNetworkingSockets (BSD-3; nixpkgs `gamenetworkingsockets`).
+#include <steam/steamnetworkingsockets.h>
+#include <steam/isteamnetworkingutils.h>
+#endif
+
+namespace dcf {
+
+namespace {
+
+// One node per process → a single active instance drives the status callback.
+SteamNet* g_self = nullptr;
+int g_init_count = 0;
+
+void on_status_trampoline(SteamNetConnectionStatusChangedCallback_t* info) {
+    if (g_self) g_self->on_conn_status(info);
+}
+
+bool backend_init(const char* identity_str, std::string& err) {
+#if defined(DCF_CPP_STEAM)
+    // Steamworks init (SteamAPI_Init / SteamGameServer_Init) is the caller's job;
+    // turn on the Steam Datagram Relay so P2P + dedicated SDR sockets work.
+    if (SteamNetworkingUtils()) SteamNetworkingUtils()->InitRelayNetworkAccess();
+    (void)identity_str;
+    (void)err;
+    return true;
+#else
+    SteamNetworkingErrMsg m;
+    SteamNetworkingIdentity id;
+    id.Clear();
+    if (identity_str && *identity_str) id.SetGenericString(identity_str);
+    if (!GameNetworkingSockets_Init(id.IsInvalid() ? nullptr : &id, m)) {
+        err = m;
+        return false;
+    }
+    return true;
+#endif
+}
+
+void backend_kill() {
+#if !defined(DCF_CPP_STEAM)
+    GameNetworkingSockets_Kill();
+#endif
+}
+
+// Build the per-socket config that routes connection-status callbacks to us.
+SteamNetworkingConfigValue_t status_cb_opt() {
+    SteamNetworkingConfigValue_t opt;
+    opt.SetPtr(k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged,
+               reinterpret_cast<void*>(on_status_trampoline));
+    return opt;
+}
+
+void push_msg(std::vector<NetMessage>& out, SteamNetworkingMessage_t* m) {
+    const char* d = static_cast<const char*>(m->m_pData);
+    const int n = m->m_cbSize;
+    NetMessage nm;
+    nm.from = m->m_conn;
+    if (n > 0) {
+        nm.reliable = (d[0] & td::FLAG_RELIABLE) != 0;
+        nm.data.assign(d + 1, static_cast<std::size_t>(n - 1));
+    }
+    out.push_back(std::move(nm));
+}
+
+}  // namespace
+
+SteamNet::SteamNet(std::string identity) : identity_(std::move(identity)) {
+    std::string err;
+    if (g_init_count == 0) {
+        if (!backend_init(identity_.c_str(), err)) {
+            std::fprintf(stderr, "[steamnet] init failed: %s\n", err.c_str());
+            return;
+        }
+    }
+    ++g_init_count;
+    g_self = this;
+    ok_ = true;
+}
+
+SteamNet::~SteamNet() {
+    if (!ok_) return;
+    ISteamNetworkingSockets* s = SteamNetworkingSockets();
+    if (s) {
+        for (ConnId c : conns_) s->CloseConnection(c, 0, "shutdown", false);
+        if (poll_group_) s->DestroyPollGroup(poll_group_);
+        if (listen_sock_) s->CloseListenSocket(listen_sock_);
+    }
+    if (g_self == this) g_self = nullptr;
+    if (--g_init_count == 0) backend_kill();
+}
+
+bool SteamNet::listen(std::uint16_t port) {
+    if (!ok_) return false;
+    server_ = true;
+    ISteamNetworkingSockets* s = SteamNetworkingSockets();
+    SteamNetworkingConfigValue_t opt = status_cb_opt();
+#if defined(DCF_CPP_STEAM)
+    // Dedicated server over the Steam Datagram Relay: a virtual port, IP hidden.
+    listen_sock_ = s->CreateListenSocketP2P(static_cast<int>(port), 1, &opt);
+#else
+    SteamNetworkingIPAddr addr;
+    addr.Clear();
+    addr.SetIPv4(0, port);  // 0.0.0.0:port
+    listen_sock_ = s->CreateListenSocketIP(addr, 1, &opt);
+#endif
+    poll_group_ = s->CreatePollGroup();
+    return listen_sock_ != k_HSteamListenSocket_Invalid;
+}
+
+ConnId SteamNet::connect(const std::string& host, std::uint16_t port) {
+    if (!ok_) return 0;
+    ISteamNetworkingSockets* s = SteamNetworkingSockets();
+    SteamNetworkingConfigValue_t opt = status_cb_opt();
+#if defined(DCF_CPP_STEAM)
+    // P2P over SDR: `host` is the peer identity (generic string / SteamID string).
+    SteamNetworkingIdentity id;
+    id.Clear();
+    id.SetGenericString(host.c_str());
+    client_conn_ = s->ConnectP2P(id, static_cast<int>(port), 1, &opt);
+#else
+    SteamNetworkingIPAddr addr;
+    addr.Clear();
+    const std::string hp = host + ":" + std::to_string(port);
+    if (!addr.ParseString(hp.c_str())) {
+        std::fprintf(stderr, "[steamnet] bad address %s\n", hp.c_str());
+        return 0;
+    }
+    client_conn_ = s->ConnectByIPAddress(addr, 1, &opt);
+#endif
+    if (client_conn_ != k_HSteamNetConnection_Invalid) conns_.push_back(client_conn_);
+    return client_conn_;
+}
+
+bool SteamNet::send(ConnId c, const void* data, std::size_t len, bool reliable) {
+    if (!ok_ || c == 0) return false;
+    const std::string dg = td::wrap(data, len, reliable);
+    const int flags = reliable ? k_nSteamNetworkingSend_Reliable : k_nSteamNetworkingSend_Unreliable;
+    const EResult r = SteamNetworkingSockets()->SendMessageToConnection(
+        c, dg.data(), static_cast<std::uint32_t>(dg.size()), flags, nullptr);
+    return r == k_EResultOK;
+}
+
+int SteamNet::broadcast_except(ConnId except, const void* data, std::size_t len, bool reliable) {
+    int sent = 0;
+    for (ConnId c : conns_)
+        if (c != except && send(c, data, len, reliable)) ++sent;
+    return sent;
+}
+
+void SteamNet::poll(std::vector<NetMessage>& out) {
+    if (!ok_) return;
+    g_self = this;
+    SteamNetworkingSockets()->RunCallbacks();
+    drain(out);
+}
+
+void SteamNet::drain(std::vector<NetMessage>& out) {
+    ISteamNetworkingSockets* s = SteamNetworkingSockets();
+    SteamNetworkingMessage_t* msgs[32];
+    if (server_) {
+        const int n = s->ReceiveMessagesOnPollGroup(poll_group_, msgs, 32);
+        for (int i = 0; i < n; ++i) {
+            push_msg(out, msgs[i]);
+            msgs[i]->Release();
+        }
+    } else {
+        for (ConnId c : conns_) {
+            const int n = s->ReceiveMessagesOnConnection(c, msgs, 32);
+            for (int i = 0; i < n; ++i) {
+                push_msg(out, msgs[i]);
+                msgs[i]->Release();
+            }
+        }
+    }
+}
+
+void SteamNet::close(ConnId c) {
+    if (!ok_ || c == 0) return;
+    SteamNetworkingSockets()->CloseConnection(c, 0, "close", false);
+    conns_.erase(std::remove(conns_.begin(), conns_.end(), c), conns_.end());
+}
+
+void SteamNet::on_conn_status(void* p) {
+    auto* info = static_cast<SteamNetConnectionStatusChangedCallback_t*>(p);
+    ISteamNetworkingSockets* s = SteamNetworkingSockets();
+    switch (info->m_info.m_eState) {
+        case k_ESteamNetworkingConnectionState_Connecting:
+            if (server_) {
+                if (s->AcceptConnection(info->m_hConn) == k_EResultOK) {
+                    s->SetConnectionPollGroup(info->m_hConn, poll_group_);
+                    conns_.push_back(info->m_hConn);
+                } else {
+                    s->CloseConnection(info->m_hConn, 0, "accept failed", false);
+                }
+            }
+            break;
+        case k_ESteamNetworkingConnectionState_Connected:
+            if (!server_ && info->m_hConn == client_conn_) client_connected_ = true;
+            break;
+        case k_ESteamNetworkingConnectionState_ClosedByPeer:
+        case k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
+            s->CloseConnection(info->m_hConn, 0, "peer closed", false);
+            conns_.erase(std::remove(conns_.begin(), conns_.end(), info->m_hConn), conns_.end());
+            if (info->m_hConn == client_conn_) {
+                client_connected_ = false;
+                client_conn_ = 0;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+}  // namespace dcf

--- a/cpp/src/steam_gameserver.cpp
+++ b/cpp/src/steam_gameserver.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// Steamworks dedicated game server — anonymous/GSLT login + master-server heartbeats
+// so a dockerized DCF hub appears in the Steam server browser. Compiled only with
+// DCF_CPP_STEAM against the developer-supplied Steamworks SDK; UNVERIFIED in CI (the
+// SDK is proprietary). See Documentation/DCF_STEAM_SPEC.md.
+
+#if defined(DCF_CPP_STEAM)
+
+#include "dcf/steam_ext.hpp"
+
+#include <steam/steam_gameserver.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace dcf {
+
+namespace {
+bool g_gs_up = false;
+}
+
+bool steam_server_register(const char* node_id, std::uint16_t game_port) {
+    // App ID is taken from steam_appid.txt (dev) or the depot at runtime. The query
+    // port carries A2S/server-browser traffic; keep it adjacent to the game port.
+    const std::uint16_t query_port = static_cast<std::uint16_t>(game_port + 1);
+    if (!SteamGameServer_Init(0 /*INADDR_ANY*/, game_port, query_port,
+                              eServerModeAuthentication, "0.3.0.0")) {
+        std::fprintf(stderr, "[steam] SteamGameServer_Init failed "
+                             "(missing steam_appid.txt / App ID / steamclient.so?)\n");
+        return false;
+    }
+    ISteamGameServer* gs = SteamGameServer();
+    gs->SetProduct("dcf");
+    gs->SetGameDescription("DeMoD Communication Framework — mesh/game node");
+    gs->SetModDir("dcf");
+    gs->SetDedicatedServer(true);
+    gs->SetServerName(node_id && *node_id ? node_id : "dcf-hub");
+    gs->SetMaxPlayerCount(64);
+
+    const char* gslt = std::getenv("DCF_STEAM_GSLT");
+    if (gslt && *gslt) gs->LogOn(gslt);   // persistent, listed token
+    else gs->LogOnAnonymous();            // anonymous account (fine for Docker)
+
+    // Heartbeats -> Steam master server -> server browser. (Older SDKs:
+    // EnableHeartbeats(true).)
+    gs->SetAdvertiseServerActive(true);
+
+    g_gs_up = true;
+    std::printf("[steam] dedicated server registered (game=%u query=%u)\n", game_port, query_port);
+    return true;
+}
+
+void steam_server_run_callbacks() {
+    if (g_gs_up) SteamGameServer_RunCallbacks();
+}
+
+void steam_server_shutdown() {
+    if (!g_gs_up) return;
+    if (ISteamGameServer* gs = SteamGameServer()) {
+        gs->SetAdvertiseServerActive(false);
+        gs->LogOff();
+    }
+    SteamGameServer_Shutdown();
+    g_gs_up = false;
+}
+
+}  // namespace dcf
+
+#endif  // DCF_CPP_STEAM

--- a/cpp/src/steam_lobby.cpp
+++ b/cpp/src/steam_lobby.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// Steamworks matchmaking lobbies — the discovery/coordination layer that maps onto a
+// DCF dst channel (lobby ↔ channel; SteamID ↔ player identity). Compiled only with
+// DCF_CPP_STEAM against the developer-supplied Steamworks SDK; UNVERIFIED in CI.
+// Lobby operations complete via Steam callbacks — pump SteamAPI_RunCallbacks().
+// See Documentation/DCF_STEAM_SPEC.md.
+
+#if defined(DCF_CPP_STEAM)
+
+#include "dcf/steam_ext.hpp"
+
+#include <steam/steam_api.h>
+
+#include <cstdio>
+
+namespace dcf {
+
+namespace {
+
+// Tracks the in-flight CreateLobby/JoinLobby calls (async → CCallResult).
+struct LobbyOps {
+    CSteamID lobby;
+    bool ready = false;
+    CCallResult<LobbyOps, LobbyCreated_t> on_create;
+    CCallResult<LobbyOps, LobbyEnter_t> on_enter;
+
+    void create(int max_members) {
+        SteamAPICall_t h = SteamMatchmaking()->CreateLobby(k_ELobbyTypePublic, max_members);
+        on_create.Set(h, this, &LobbyOps::Created);
+    }
+    void Created(LobbyCreated_t* r, bool io_fail) {
+        if (io_fail || r->m_eResult != k_EResultOK) {
+            std::fprintf(stderr, "[steam] CreateLobby failed (%d)\n", r ? r->m_eResult : -1);
+            return;
+        }
+        lobby = CSteamID(r->m_ulSteamIDLobby);
+        ready = true;
+        std::printf("[steam] lobby created: %llu\n", (unsigned long long)lobby.ConvertToUint64());
+    }
+
+    void join(std::uint64_t id) {
+        SteamAPICall_t h = SteamMatchmaking()->JoinLobby(CSteamID(id));
+        on_enter.Set(h, this, &LobbyOps::Entered);
+    }
+    void Entered(LobbyEnter_t* r, bool io_fail) {
+        if (io_fail) {
+            std::fprintf(stderr, "[steam] JoinLobby failed\n");
+            return;
+        }
+        lobby = CSteamID(r->m_ulSteamIDLobby);
+        ready = true;
+        std::printf("[steam] lobby joined: %llu (members=%d)\n",
+                    (unsigned long long)lobby.ConvertToUint64(),
+                    SteamMatchmaking()->GetNumLobbyMembers(lobby));
+    }
+};
+
+LobbyOps g_lobby;
+
+}  // namespace
+
+std::uint64_t steam_lobby_create(int max_members) {
+    g_lobby.create(max_members);
+    return g_lobby.lobby.ConvertToUint64();  // 0 until the LobbyCreated_t callback fires
+}
+
+bool steam_lobby_join(std::uint64_t lobby_id) {
+    g_lobby.join(lobby_id);
+    return true;
+}
+
+void steam_lobby_set_data(std::uint64_t lobby_id, const char* key, const char* val) {
+    SteamMatchmaking()->SetLobbyData(CSteamID(lobby_id), key, val);
+}
+
+}  // namespace dcf
+
+#endif  // DCF_CPP_STEAM

--- a/cpp/tests/gns_loopback.sh
+++ b/cpp/tests/gns_loopback.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# Integration test for the DCF Steam-compatible (GameNetworkingSockets) transport:
+# start a `serve-gns` hub, connect two clients, and assert that a certified DCF frame
+# sent reliably by client A is forwarded by the hub and received by client B intact.
+#
+#   gns_loopback.sh /path/to/dcfcpp [port]
+set -euo pipefail
+
+BIN="${1:?usage: gns_loopback.sh <dcfcpp> [port]}"
+PORT="${2:-27620}"
+FRAME="d31312340001ffffdeadbeefab12cd24c0"   # certified golden frame (dst=0xFFFF)
+
+WORK="$(mktemp -d)"
+trap 'kill "${HUB:-}" 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+"$BIN" serve-gns --port "$PORT" --node-id hub >"$WORK/hub.log" 2>&1 &
+HUB=$!
+sleep 0.6
+
+"$BIN" connect-gns --peer "127.0.0.1:$PORT" --node-id B --listen 3 >"$WORK/b.log" 2>&1 &
+sleep 0.6
+
+"$BIN" connect-gns --peer "127.0.0.1:$PORT" --node-id A --send-hex "$FRAME" --reliable --listen 2 \
+    >"$WORK/a.log" 2>&1
+sleep 2.2
+
+echo "--- hub ---"; cat "$WORK/hub.log"
+echo "--- A ---";   cat "$WORK/a.log"
+echo "--- B ---";   cat "$WORK/b.log"
+
+if grep -qi "$FRAME" "$WORK/b.log"; then
+    echo "PASS: client B received client A's frame via the hub"
+    exit 0
+fi
+echo "FAIL: frame not forwarded to B"
+exit 1

--- a/docker/build-and-push.sh
+++ b/docker/build-and-push.sh
@@ -22,6 +22,8 @@
 #   dcf-python, dcf-nodejs  — bare DeModFrame + SuperPack/UDP (mesh with each other)
 #   dcf-c                   — also a Faust-DSP modem (send-modem/recv-modem over a medium)
 #   dcf-cpp                 — a gRPC node (bidi MeshStream)
+#   dcf-gns                 — Steam-compatible dedicated server (GameNetworkingSockets
+#                             hub: serve-gns; clients connect-gns). See DCF_STEAM_SPEC.md.
 #
 # Builds run at low priority with capped cores (nice + --cores) so they don't
 # saturate the machine. Set NICE=0 to disable.
@@ -56,6 +58,7 @@ case "$target" in
   dcf-nodejs) build_one dcf-nodejs docker-dcf-nodejs ;;
   dcf-c)      build_one dcf-c      docker-dcf-c ;;
   dcf-cpp)    build_one dcf-cpp    docker-dcf-cpp ;;
+  dcf-gns)    build_one dcf-gns    docker-dcf-gns ;;
   all)
     build_one dcf-go     docker-dcf-go
     build_one dcf-rs     docker-dcf-rust
@@ -63,7 +66,8 @@ case "$target" in
     build_one dcf-nodejs docker-dcf-nodejs
     build_one dcf-c      docker-dcf-c
     build_one dcf-cpp    docker-dcf-cpp
+    build_one dcf-gns    docker-dcf-gns
     ;;
-  *) echo "unknown target: $target (dcf-go|dcf-rs|dcf-python|dcf-nodejs|dcf-c|dcf-cpp|all)"; exit 2 ;;
+  *) echo "unknown target: $target (dcf-go|dcf-rs|dcf-python|dcf-nodejs|dcf-c|dcf-cpp|dcf-gns|all)"; exit 2 ;;
 esac
 echo "DONE"

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,36 @@
             meta.mainProgram = "dcfcpp";
           };
 
+          # C++ node with the Steam-compatible transport on the open
+          # GameNetworkingSockets (BSD-3) — Valve's same ISteamNetworkingSockets API
+          # the Steamworks SDK exposes, so this same dcfcpp recompiles against the
+          # proprietary SDK (DCF_CPP_STEAM, developer-supplied) for SDR relay +
+          # lobbies. `serve-gns` is the dedicated-server hub; `connect-gns` a client.
+          # See Documentation/DCF_STEAM_SPEC.md. NOTE: nixpkgs GNS 1.4.1 ships
+          # without WebRTC/ICE, so internet NAT-punch P2P needs the Steam SDR backend
+          # or a WebRTC-enabled GNS; LAN/direct + hub forwarding work here.
+          dcf-cpp-gns = pkgs.stdenv.mkDerivation {
+            pname = "dcf-cpp-gns";
+            version = "0.3.0";
+            src = self + "/cpp";
+            nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config ];
+            buildInputs = [ pkgs.gamenetworkingsockets pkgs.protobuf pkgs.openssl ];
+            cmakeFlags = [
+              "-DDCF_CPP_GRPC=OFF"
+              "-DDCF_CPP_GNS=ON"
+              "-DDCF_GNS_INCLUDE_DIR=${pkgs.gamenetworkingsockets}/include/GameNetworkingSockets"
+              "-DDCF_GNS_LIB_DIR=${pkgs.gamenetworkingsockets}/lib"
+            ];
+            buildPhase = "cmake --build . --target dcfcpp -j$NIX_BUILD_CORES";
+            installPhase = ''
+              mkdir -p $out/bin
+              cp dcfcpp $out/bin/dcfcpp
+            '';
+            meta.description = "DCF C++ Steam-compatible node (GameNetworkingSockets)";
+            meta.license = pkgs.lib.licenses.lgpl3Only;
+            meta.mainProgram = "dcfcpp";
+          };
+
           # Go SDK — builds the dcfnode CLI (a real UDP DeModFrame node, the Go
           # analogue of the Rust `dcf` binary). The module is stdlib-only (no
           # external deps, no gRPC/proto), so vendorHash = null.
@@ -269,6 +299,22 @@
               Entrypoint = [ "${dcf-cpp}/bin/dcfcpp" ];
               Cmd = [ "serve" ];
               ExposedPorts = { "50051/tcp" = { }; };
+              Labels = { "org.opencontainers.image.source" = "https://github.com/ALH477/HydraMesh"; };
+            };
+          };
+
+          # Steam-compatible dedicated-server image: the GameNetworkingSockets hub.
+          # `nix build .#docker-dcf-gns`. Clients connect with `dcfcpp connect-gns
+          # --peer host:27015`. Steam SDR/lobbies need the developer-supplied
+          # Steamworks build (cpp/Dockerfile.steam), not this hermetic image.
+          docker-dcf-gns = pkgs.dockerTools.buildLayeredImage {
+            name = "alh477/dcf-gns";
+            tag = "latest";
+            contents = [ dcf-cpp-gns pkgs.cacert ];
+            config = {
+              Entrypoint = [ "${dcf-cpp-gns}/bin/dcfcpp" ];
+              Cmd = [ "serve-gns" "--port" "27015" ];
+              ExposedPorts = { "27015/udp" = { }; };
               Labels = { "org.opencontainers.image.source" = "https://github.com/ALH477/HydraMesh"; };
             };
           };

--- a/node/docker-compose.gns.yml
+++ b/node/docker-compose.gns.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# A Steam-compatible DCF dedicated server (the GameNetworkingSockets hub). Clients
+# connect with `dcfcpp connect-gns --peer <host>:27015`. Build the image first:
+#   nix build .#docker-dcf-gns && docker load < result
+# Then:  docker compose -f node/docker-compose.gns.yml up
+#
+# This is the open/hermetic backend (LAN/direct + hub forwarding). For Steam SDR
+# relay + lobbies + server browser, build the developer-supplied Steamworks image
+# (cpp/Dockerfile.steam) instead. See Documentation/DCF_STEAM_SPEC.md.
+services:
+  dcf-gns:
+    image: alh477/dcf-gns:latest
+    hostname: dcf-gns
+    restart: unless-stopped
+    command: ["serve-gns", "--port", "27015", "--node-id", "dcf-gns-hub"]
+    ports:
+      - "27015:27015/udp"   # GameNetworkingSockets (UDP); deploy behind WireGuard
+    deploy:
+      resources:
+        limits: { cpus: "1.0", memory: "256M" }


### PR DESCRIPTION
…orks)

Make the DCF mesh speak Valve's ISteamNetworkingSockets: Steam P2P for clients and dedicated servers that are the Docker containers / node runtime. It is a transport *under* the certified wire — the 17-byte DeModFrame and every adapter are unchanged; DCF-Steam only carries those bytes.

One transport, two backends (same source recompiles against either):
  • DCF_CPP_GNS  (default, hermetic): open GameNetworkingSockets (BSD-3, nixpkgs).
    Dedicated-server hub (serve-gns), client (connect-gns), LAN/direct + hub P2P.
  • DCF_CPP_STEAM (opt-in, developer-supplied SDK): SDR relay, lobbies, server
    browser via ISteamGameServer/ISteamMatchmaking. Backends differ in ~6 calls
    behind #if; send/recv/hub/framing is shared, so the GNS build exercises the
    Steam build's wire logic.

Mappings: DCF-Game FLAG_RELIABLE -> k_nSteamNetworkingSend_Reliable; dst channel <-> lobby; src_id <-> SteamID slot. A 1-byte transport datagram preserves reliability across the hub. GNS/Steam crypto sits beneath the codec (the DCF_SECURITY_EXPOSURE.md WireGuard rule) — the DCF payload stays plaintext.

Steamworks licensing: SDK is proprietary/non-redistributable — never vendored; only redistributable_bin ships in object form (cpp/Dockerfile.steam); no steam_appid.txt in prod. Enforced by cpp/.gitignore + a DCF_CPP_STEAM CMake warning.

Verified: gns_loopback ctest (hub forwards a reliable certified frame A->B); nix build .#dcf-cpp-gns and .#docker-dcf-gns; existing .#dcf-cpp (gRPC) still builds. The Steam backend is compile-guarded and unverified (needs the developer SDK + App ID + GSLT). Note: nixpkgs GNS 1.4.1 ships without WebRTC/ICE, so internet NAT-punch P2P needs the Steam SDR backend; LAN/direct + hub work today.

New: cpp/include/dcf/{transport,net_steam,steam_ext}.hpp, cpp/src/{net_steam,steam_gameserver,steam_lobby}.cpp, cpp/tests/gns_loopback.sh, cpp/Dockerfile.steam, cpp/.gitignore, node/docker-compose.gns.yml, Documentation/DCF_STEAM_SPEC.md.

<!-- Thanks for contributing to HydraMesh! See CONTRIBUTING.md. -->

## What & why

<!-- What does this change, and why? Link any related issue (e.g. "Closes #123"). -->

## How tested

<!-- Commands you ran and their result. -->

## Checklist

- [ ] Branched off `main`; the change is focused.
- [ ] Matches the style of the surrounding code.
- [ ] Ran the relevant per-language tests.
- [ ] **If I touched the wire/audio path:** regenerated the golden vectors and ran
      `make certify` (or the Python/Rust/C certs) — they pass, and the
      `Documentation/` + `python/MCP/` vector copies are identical.
- [ ] No new wire format and no encryption added to the core wire path.
- [ ] New files carry the appropriate `SPDX-License-Identifier` (LGPL-3.0-only for
      the library).
